### PR TITLE
Seamless transfer by reference strategy is improved.

### DIFF
--- a/Seamless-Tests.package/SeamlessTransferByReferenceStrategyTests.class/instance/testTransferPreparationShouldIgnoreCacheWhenReferenceIsRemote.st
+++ b/Seamless-Tests.package/SeamlessTransferByReferenceStrategyTests.class/instance/testTransferPreparationShouldIgnoreCacheWhenReferenceIsRemote.st
@@ -1,0 +1,11 @@
+tests
+testTransferPreparationShouldIgnoreCacheWhenReferenceIsRemote
+
+	| transferObject reference |
+	reference := Mock new.
+	(transporter stub referenceFor: #object) willReturn: reference.
+	reference stub pointsToRemoteObject willReturn: true.
+
+	transferObject := strategy prepareTransferObjectFor: #object by: transporter.
+	
+	transferObject should be: reference

--- a/Seamless.package/SeamlessObjectReference.class/instance/pointsToRemoteObject.st
+++ b/Seamless.package/SeamlessObjectReference.class/instance/pointsToRemoteObject.st
@@ -1,0 +1,4 @@
+testing
+pointsToRemoteObject
+
+	^senderPeer class ~~ BasysLocalPeer

--- a/Seamless.package/SeamlessTransferByReferenceStrategy.class/instance/prepareTransferObjectFor.by..st
+++ b/Seamless.package/SeamlessTransferByReferenceStrategy.class/instance/prepareTransferObjectFor.by..st
@@ -3,6 +3,10 @@ prepareTransferObjectFor: anObject by: anObjectTransporter
  
 	| reference |
 	reference := anObjectTransporter referenceFor: anObject.
+	reference pointsToRemoteObject ifTrue: [ 
+		"no need for cache when we just return existing remote reference to another peer
+		which can be also owner peer which sent cached properties here"
+		^reference ]. 
 	
 	cachedMessages do: [ :each | 
 		reference cacheMessage: each with: (anObject perform: each)].


### PR DESCRIPTION
Seamless transfer by reference strategy is improved.
It ignore cached properties when reference points to remote peer