### PR TITLE
SeamlessTimeout

### DIFF
--- a/Seamless.package/SeamlessSyncRequestContext.class/instance/sendRequest..st
+++ b/Seamless.package/SeamlessSyncRequestContext.class/instance/sendRequest..st
@@ -5,7 +5,7 @@ sendRequest: aSeamlessRequest
 	
 	self forkProcessingOf: aSeamlessRequest.
 
-	resultWaiter wait.
+	resultWaiter waitTimeoutSeconds: 3.
 	
 	"Here we fix data statistics about request execution"
 	aSeamlessRequest resultBytes: result transferredBytes.


### PR DESCRIPTION
Inserted one timeout, because if you lost the connection, Pharo freezes.