### PR TITLE
Fix remote doIts with globals which are missing in local image

### DIFF
--- a/Seamless-GTSupport.package/SeamlessRemoteClassCompiler.class/instance/evaluate.st
+++ b/Seamless-GTSupport.package/SeamlessRemoteClassCompiler.class/instance/evaluate.st
@@ -1,33 +1,27 @@
 evaluation
 evaluate
+
 	| value selectedSource itsSelection itsSelectionString doItMethod |
-	receiver isRemoteDoItReceiver
-		ifTrue: [ compilationContext := SeamlessRemoteClassCompilationContext
-				on: receiver remoteClass
-				requestor: compilationContext requestor.
-				compilationContext environment: receiver ]
-		ifFalse: [ self
-				class:
-					(context
-						ifNil: [ receiver remoteClass ]
-						ifNotNil: [ context method methodClass ]) ].
+	receiver isRemoteDoItReceiver 
+		ifTrue: [compilationContext := SeamlessRemoteClassCompilationContext on: receiver remoteClass requestor: compilationContext requestor.
+			compilationContext environment: receiver]
+		ifFalse: [ self class: (context 
+				ifNil: [ receiver remoteClass ]
+				ifNotNil: [ context method methodClass ])].
 	self noPattern: true.
-	selectedSource := ((self compilationContext requestor
-		respondsTo: #selection)
-		and: [ (itsSelection := self compilationContext requestor selection) notNil
+	selectedSource := ((self compilationContext requestor respondsTo: #selection)
+		and: [ 
+			(itsSelection := self compilationContext requestor selection) notNil
 				and: [ (itsSelectionString := itsSelection asString) isEmptyOrNil not ] ])
 		ifTrue: [ itsSelectionString ]
 		ifFalse: [ source ].
 	self source: selectedSource.
-	doItMethod := self parse generateWithSource.
-	value := receiver
-		withArgs: (context ifNil: [ #() ] ifNotNil: [ {context} ])
-		executeMethod: doItMethod.
+	doItMethod := self translate generateWithSource.
+	
+	value := receiver withArgs: (context ifNil: [ #() ] ifNotNil: [ {context} ]) executeMethod:  doItMethod.
 	self compilationContext logged
-		ifTrue: [ Smalltalk globals
-				at: #SystemAnnouncer
-				ifPresent: [ :sysAnn | 
-					sysAnn uniqueInstance
-						evaluated: selectedSource contents
-						context: context ] ].
+		ifTrue: [ Smalltalk globals 
+			at: #SystemAnnouncer 
+			ifPresent: [ :sysAnn | 
+				sysAnn uniqueInstance evaluated: selectedSource contents context: context ] ].
 	^ value

--- a/Seamless-GTSupport.package/SeamlessRemoteClassCompiler.class/instance/evaluate.st
+++ b/Seamless-GTSupport.package/SeamlessRemoteClassCompiler.class/instance/evaluate.st
@@ -1,26 +1,33 @@
 evaluation
 evaluate
-
 	| value selectedSource itsSelection itsSelectionString doItMethod |
-	receiver isRemoteDoItReceiver 
-		ifTrue: [compilationContext := SeamlessRemoteClassCompilationContext on: receiver remoteClass requestor: compilationContext requestor]
-		ifFalse: [ self class: (context 
-				ifNil: [ receiver remoteClass ]
-				ifNotNil: [ context method methodClass ])].
+	receiver isRemoteDoItReceiver
+		ifTrue: [ compilationContext := SeamlessRemoteClassCompilationContext
+				on: receiver remoteClass
+				requestor: compilationContext requestor.
+				compilationContext environment: receiver ]
+		ifFalse: [ self
+				class:
+					(context
+						ifNil: [ receiver remoteClass ]
+						ifNotNil: [ context method methodClass ]) ].
 	self noPattern: true.
-	selectedSource := ((self compilationContext requestor respondsTo: #selection)
-		and: [ 
-			(itsSelection := self compilationContext requestor selection) notNil
+	selectedSource := ((self compilationContext requestor
+		respondsTo: #selection)
+		and: [ (itsSelection := self compilationContext requestor selection) notNil
 				and: [ (itsSelectionString := itsSelection asString) isEmptyOrNil not ] ])
 		ifTrue: [ itsSelectionString ]
 		ifFalse: [ source ].
 	self source: selectedSource.
-	doItMethod := self translate generateWithSource.
-	
-	value := receiver withArgs: (context ifNil: [ #() ] ifNotNil: [ {context} ]) executeMethod:  doItMethod.
+	doItMethod := self parse generateWithSource.
+	value := receiver
+		withArgs: (context ifNil: [ #() ] ifNotNil: [ {context} ])
+		executeMethod: doItMethod.
 	self compilationContext logged
-		ifTrue: [ Smalltalk globals 
-			at: #SystemAnnouncer 
-			ifPresent: [ :sysAnn | 
-				sysAnn uniqueInstance evaluated: selectedSource contents context: context ] ].
+		ifTrue: [ Smalltalk globals
+				at: #SystemAnnouncer
+				ifPresent: [ :sysAnn | 
+					sysAnn uniqueInstance
+						evaluated: selectedSource contents
+						context: context ] ].
 	^ value


### PR DESCRIPTION
In case of remote doIt in playground the RemoteDoItReceiver is set as an environment of remote compilation context.
It fixes variable lookup in compatible way for 6, 7 and 8 pharo versions