### PR TITLE
Adopt tests for last Mocketry version

### DIFF
--- a/Seamless-Tests.package/BasysRemotePeerTestCase.extension/instance/testEvaluationBlockRemotelly.st
+++ b/Seamless-Tests.package/BasysRemotePeerTestCase.extension/instance/testEvaluationBlockRemotelly.st
@@ -10,6 +10,6 @@ testEvaluationBlockRemotelly
 		
 		(peer evaluate: block) should be: #result.
 		Arg request should beInstanceOf: SeamlessBlockEvaluationRequest.
-		Arg request valuable should be: localBlock
+		Arg request where valuable should be: localBlock
 	] runWithMocks 
 	

--- a/Seamless-Tests.package/SeamlessLoadDeepCopyRequestTests.class/instance/testExecution.st
+++ b/Seamless-Tests.package/SeamlessLoadDeepCopyRequestTests.class/instance/testExecution.st
@@ -11,4 +11,4 @@ testExecution
 	request executeFor: #senderPeer.
 	
 	Arg container should beInstanceOf: SeamlessDeepCopyContainer.
-	Arg container content should be: #localObjectForReference
+	Arg container where content should be: #localObjectForReference

--- a/Seamless-Tests.package/SeamlessLoadObjectRequestTests.class/instance/testExecution.st
+++ b/Seamless-Tests.package/SeamlessLoadObjectRequestTests.class/instance/testExecution.st
@@ -11,4 +11,4 @@ testExecution
 	request executeFor: #senderPeer.
 	
 	Arg container should beInstanceOf: SeamlessObjectValueContainer.
-	Arg container content should be: #localObjectForReference
+	Arg container where content should be: #localObjectForReference

--- a/Seamless-Tests.package/SeamlessMessageSendRequestTests.class/instance/testExecutionWithBasysCommunicationFailure.st
+++ b/Seamless-Tests.package/SeamlessMessageSendRequestTests.class/instance/testExecutionWithBasysCommunicationFailure.st
@@ -12,6 +12,6 @@ testExecutionWithBasysCommunicationFailure
 		request executeFor: #senderPeer.
 		
 		Arg result should beInstanceOf: SeamlessThrowExceptionResult.
-		Arg result exception should beInstanceOf: SeamlessRemoteException.
-		Arg result exception messageText should equal: error printString
+		Arg result where exception should beInstanceOf: SeamlessRemoteException.
+		Arg result where exception messageText should equal: error printString
 	] runWithMocks 

--- a/Seamless-Tests.package/SeamlessMessageSendRequestTests.class/instance/testExecutionWithNonLocalReturn.st
+++ b/Seamless-Tests.package/SeamlessMessageSendRequestTests.class/instance/testExecutionWithNonLocalReturn.st
@@ -11,6 +11,6 @@ testExecutionWithNonLocalReturn
 		request executeFor: #senderPeer.
 		
 		Arg result should beInstanceOf: SeamlessNonLocalReturnResult.
-		Arg result fromFirstCall value should be: #returnedValue.
-		Arg result homeContext should be: #context
+		Arg result where value should be: #returnedValue.
+		Arg result where homeContext should be: #context
 	] runWithMocks 

--- a/Seamless-Tests.package/SeamlessMessageSendRequestTests.class/instance/testExecutionWithNormalResult.st
+++ b/Seamless-Tests.package/SeamlessMessageSendRequestTests.class/instance/testExecutionWithNormalResult.st
@@ -9,5 +9,5 @@ testExecutionWithNormalResult
 		request executeFor: #senderPeer.
 
 		Arg result should beInstanceOf: SeamlessReturnValueResult.
-		Arg result returnValue should be: #messageResult
+		Arg result where returnValue should be: #messageResult
 	] runWithMocks 

--- a/Seamless-Tests.package/SeamlessMessageSendRequestTests.class/instance/testExecutionWithRaisedError.st
+++ b/Seamless-Tests.package/SeamlessMessageSendRequestTests.class/instance/testExecutionWithRaisedError.st
@@ -11,6 +11,6 @@ testExecutionWithRaisedError
 		request executeFor: #senderPeer.
 		
 		Arg result should beInstanceOf: SeamlessThrowExceptionResult.
-		Arg result exception should beInstanceOf: SeamlessRemoteException.
-		Arg result exception messageText should equal: error printString
+		Arg result where exception should beInstanceOf: SeamlessRemoteException.
+		Arg result where exception messageText should equal: error printString
 	] runWithMocks 

--- a/Seamless-Tests.package/SeamlessMessageSendRequestTests.class/instance/testExecutionWithRaisedSeamlessRemoteException.st
+++ b/Seamless-Tests.package/SeamlessMessageSendRequestTests.class/instance/testExecutionWithRaisedSeamlessRemoteException.st
@@ -11,6 +11,6 @@ testExecutionWithRaisedSeamlessRemoteException
 		request executeFor: #senderPeer.
 		
 		Arg result should beInstanceOf: SeamlessThrowExceptionResult.
-		Arg result exception should beInstanceOf: SeamlessRemoteException.
+		Arg result where exception should beInstanceOf: SeamlessRemoteException.
 		"Arg result exception messageText should equal: error messageText."
 	] runWithMocks 

--- a/Seamless-Tests.package/SeamlessNetworkTests.class/instance/testGettingReferenceForObject.st
+++ b/Seamless-Tests.package/SeamlessNetworkTests.class/instance/testGettingReferenceForObject.st
@@ -11,4 +11,4 @@ testGettingReferenceForObject
 	actual := network referenceFor: #object.
 	
 	actual should be: #reference.
-	Arg creationBlock fromFirstCall value should beInstanceOf: SeamlessObjectReference
+	Arg creationBlock where value should beInstanceOf: SeamlessObjectReference

--- a/Seamless-Tests.package/SeamlessObjectReferenceTests.class/instance/testLoadingRealObject.st
+++ b/Seamless-Tests.package/SeamlessObjectReferenceTests.class/instance/testLoadingRealObject.st
@@ -9,5 +9,5 @@ testLoadingRealObject
 		(reference loadObject: #proxy) should be: #result.
 	
 		Arg request should beInstanceOf: SeamlessLoadObjectRequest.
-		Arg request objectProxy should be: #proxy.
+		Arg request where objectProxy should be: #proxy.
 	 ] runWithMocks 

--- a/Seamless-Tests.package/SeamlessObjectReferenceTests.class/instance/testLoadingRealObjectAsDeepCopy.st
+++ b/Seamless-Tests.package/SeamlessObjectReferenceTests.class/instance/testLoadingRealObjectAsDeepCopy.st
@@ -9,5 +9,5 @@ testLoadingRealObjectAsDeepCopy
 		(reference loadDeepCopy: #proxy) should be: #result.
 	
 		Arg request should beInstanceOf: SeamlessLoadDeepCopyRequest.
-		Arg request objectProxy should be: #proxy.
+		Arg request where objectProxy should be: #proxy.
 	 ] runWithMocks 

--- a/Seamless-Tests.package/SeamlessRemoteContextTests.class/instance/testReturningResult.st
+++ b/Seamless-Tests.package/SeamlessRemoteContextTests.class/instance/testReturningResult.st
@@ -9,6 +9,6 @@ testReturningResult
 		network removeDistributedObject: context].
 	
 		Arg request should beInstanceOf: SeamlessDeliverResultRequest.
-		Arg request context should be: context.
-		Arg request result should be: #result
+		Arg request where context should be: context.
+		Arg request where result should be: #result
 	 ] runWithMocks 

--- a/Seamless-Tests.package/SeamlessSyncRequestContextTests.class/instance/testSendingMessage.st
+++ b/Seamless-Tests.package/SeamlessSyncRequestContextTests.class/instance/testSendingMessage.st
@@ -6,4 +6,4 @@ testSendingMessage
 	(context sendMessage: #messageSend) should be: #result.
 	
 	Arg request should beInstanceOf: SeamlessMessageSendRequest.
-	Arg request messageSend should be: #messageSend
+	Arg request where messageSend should be: #messageSend

--- a/Seamless-Tests.package/SeamlessTransferByReferencedCopyStrategyTests.class/instance/testTransferPreparation.st
+++ b/Seamless-Tests.package/SeamlessTransferByReferencedCopyStrategyTests.class/instance/testTransferPreparation.st
@@ -1,14 +1,13 @@
 tests
 testTransferPreparation
 
-	| object transferObject newReference |
+	| object transferObject |
 	object := 'object' copy.
 	(transporter stub referenceFor: 'object' ifNewUse: Arg block) willReturn: #reference.
 	
 	transferObject := strategy prepareTransferObjectFor: #object by: transporter.
 	
 	transferObject should be: #reference. 
-	newReference := Arg block fromFirstCall value.
-	newReference should beInstanceOf: SeamlessObjectCopyReference.
-	newReference objectCopy should equal: object.
-	newReference objectCopy should not be: object.
+	Arg block where value should beInstanceOf: SeamlessObjectCopyReference.
+	Arg block where value objectCopy should equal: object.
+	Arg block where value objectCopy should not be: object.


### PR DESCRIPTION
In recent Mocketry update there was a change in argument capture validation API.
Here Seamless tests are adopted