### PR TITLE
update Ghost to be compatible with Pharo8

### DIFF
--- a/BaselineOfSeamless/BaselineOfSeamless.class.st
+++ b/BaselineOfSeamless/BaselineOfSeamless.class.st
@@ -26,7 +26,7 @@ BaselineOfSeamless >> baseline: spec [
 			"------------"								
 			baseline: 'Ghost' with: [
 				spec
-					repository: 'github://pharo-ide/Ghost:v5.0.0';
+					repository: 'github://pharo-ide/Ghost:v5.0.2';
 					loads: 'ObjectGhost' ];
 			project: 'GhostTests' copyFrom: 'Ghost' with: [
 				spec loads: 'default'];


### PR DESCRIPTION
In Pharo 8 tests are read due to incompatible version of Ghost (related to asCollectionElement rename)