### PR TITLE
Request processing timeout

### DIFF
--- a/BaselineOfSeamless/BaselineOfSeamless.class.st
+++ b/BaselineOfSeamless/BaselineOfSeamless.class.st
@@ -12,7 +12,7 @@ BaselineOfSeamless >> baseline: spec [
 		spec 
 			baseline: 'Basys' with: [
 				spec
-					repository: 'github://pharo-ide/Basys:v1.0.3';
+					repository: 'github://pharo-ide/Basys:v1.0.4';
 					loads: 'Core' ];
 			project: 'BasysTests' copyFrom: 'Basys' with: [
 				spec loads: 'Tests'];

--- a/BaselineOfSeamless/BaselineOfSeamless.class.st
+++ b/BaselineOfSeamless/BaselineOfSeamless.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #BaselineOfSeamless,
 	#superclass : #BaselineOf,
-	#category : 'BaselineOfSeamless'
+	#category : #BaselineOfSeamless
 }
 
 { #category : #baselines }
@@ -12,7 +12,7 @@ BaselineOfSeamless >> baseline: spec [
 		spec 
 			baseline: 'Basys' with: [
 				spec
-					repository: 'github://pharo-ide/Basys:v1.0.2';
+					repository: 'github://pharo-ide/Basys:v1.0.3';
 					loads: 'Core' ];
 			project: 'BasysTests' copyFrom: 'Basys' with: [
 				spec loads: 'Tests'];

--- a/Seamless-GTSupport/SeamlessRemoteClassCompiler.class.st
+++ b/Seamless-GTSupport/SeamlessRemoteClassCompiler.class.st
@@ -13,33 +13,38 @@ SeamlessRemoteClassCompiler >> compilationContext [
 
 { #category : #evaluation }
 SeamlessRemoteClassCompiler >> evaluate [
-
 	| value selectedSource itsSelection itsSelectionString doItMethod |
-	receiver isRemoteDoItReceiver 
-		ifTrue: [compilationContext := SeamlessRemoteClassCompilationContext on: receiver remoteClass requestor: compilationContext requestor.
-			compilationContext environment: receiver]
-		ifFalse: [ self class: (context 
-				ifNil: [ receiver remoteClass ]
-				ifNotNil: [ context method methodClass ])].
-	(compilationContext respondsTo: #productionEnvironment:) ifTrue: [ 
-		"Compatibility with Pharo 8"
-		compilationContext productionEnvironment: self class environment].
-	
+	receiver isRemoteDoItReceiver
+		ifTrue: [ compilationContext := SeamlessRemoteClassCompilationContext
+				on: receiver remoteClass
+				requestor: compilationContext requestor.
+			compilationContext environment: receiver ]
+		ifFalse: [ self
+				class:
+					(context
+						ifNil: [ receiver remoteClass ]
+						ifNotNil: [ context method methodClass ]) ].
+	(compilationContext respondsTo: #productionEnvironment:)
+		ifTrue:
+			[ "Compatibility with Pharo 8" compilationContext productionEnvironment: self class environment ].
 	self noPattern: true.
-	selectedSource := ((self compilationContext requestor respondsTo: #selection)
-		and: [ 
-			(itsSelection := self compilationContext requestor selection) notNil
+	selectedSource := ((self compilationContext requestor
+		respondsTo: #selection)
+		and: [ (itsSelection := self compilationContext requestor selection) notNil
 				and: [ (itsSelectionString := itsSelection asString) isEmptyOrNil not ] ])
 		ifTrue: [ itsSelectionString ]
 		ifFalse: [ source ].
 	self source: selectedSource.
-	doItMethod := self translate methodNode generateWithSource.
-	
-	value := receiver withArgs: (context ifNil: [ #() ] ifNotNil: [ {context} ]) executeMethod:  doItMethod.
+	doItMethod := self parse methodNode generateWithSource.
+	value := receiver
+		withArgs: (context ifNil: [ #() ] ifNotNil: [ {context} ])
+		executeMethod: doItMethod.
 	self compilationContext logged
-		ifTrue: [ Smalltalk globals 
-			at: #SystemAnnouncer 
-			ifPresent: [ :sysAnn | 
-				sysAnn uniqueInstance evaluated: selectedSource contents context: context ] ].
+		ifTrue: [ Smalltalk globals
+				at: #SystemAnnouncer
+				ifPresent: [ :sysAnn | 
+					sysAnn uniqueInstance
+						evaluated: selectedSource contents
+						context: context ] ].
 	^ value
 ]

--- a/Seamless-GTSupport/SeamlessRemoteClassCompiler.class.st
+++ b/Seamless-GTSupport/SeamlessRemoteClassCompiler.class.st
@@ -13,38 +13,33 @@ SeamlessRemoteClassCompiler >> compilationContext [
 
 { #category : #evaluation }
 SeamlessRemoteClassCompiler >> evaluate [
+
 	| value selectedSource itsSelection itsSelectionString doItMethod |
-	receiver isRemoteDoItReceiver
-		ifTrue: [ compilationContext := SeamlessRemoteClassCompilationContext
-				on: receiver remoteClass
-				requestor: compilationContext requestor.
-			compilationContext environment: receiver ]
-		ifFalse: [ self
-				class:
-					(context
-						ifNil: [ receiver remoteClass ]
-						ifNotNil: [ context method methodClass ]) ].
-	(compilationContext respondsTo: #productionEnvironment:)
-		ifTrue:
-			[ "Compatibility with Pharo 8" compilationContext productionEnvironment: self class environment ].
+	receiver isRemoteDoItReceiver 
+		ifTrue: [compilationContext := SeamlessRemoteClassCompilationContext on: receiver remoteClass requestor: compilationContext requestor.
+			compilationContext environment: receiver]
+		ifFalse: [ self class: (context 
+				ifNil: [ receiver remoteClass ]
+				ifNotNil: [ context method methodClass ])].
+	(compilationContext respondsTo: #productionEnvironment:) ifTrue: [ 
+		"Compatibility with Pharo 8"
+		compilationContext productionEnvironment: self class environment].
+	
 	self noPattern: true.
-	selectedSource := ((self compilationContext requestor
-		respondsTo: #selection)
-		and: [ (itsSelection := self compilationContext requestor selection) notNil
+	selectedSource := ((self compilationContext requestor respondsTo: #selection)
+		and: [ 
+			(itsSelection := self compilationContext requestor selection) notNil
 				and: [ (itsSelectionString := itsSelection asString) isEmptyOrNil not ] ])
 		ifTrue: [ itsSelectionString ]
 		ifFalse: [ source ].
 	self source: selectedSource.
 	doItMethod := self parse methodNode generateWithSource.
-	value := receiver
-		withArgs: (context ifNil: [ #() ] ifNotNil: [ {context} ])
-		executeMethod: doItMethod.
+	
+	value := receiver withArgs: (context ifNil: [ #() ] ifNotNil: [ {context} ]) executeMethod:  doItMethod.
 	self compilationContext logged
-		ifTrue: [ Smalltalk globals
-				at: #SystemAnnouncer
-				ifPresent: [ :sysAnn | 
-					sysAnn uniqueInstance
-						evaluated: selectedSource contents
-						context: context ] ].
+		ifTrue: [ Smalltalk globals 
+			at: #SystemAnnouncer 
+			ifPresent: [ :sysAnn | 
+				sysAnn uniqueInstance evaluated: selectedSource contents context: context ] ].
 	^ value
 ]

--- a/Seamless-Tests/BasysRemotePeerTestCase.extension.st
+++ b/Seamless-Tests/BasysRemotePeerTestCase.extension.st
@@ -16,8 +16,7 @@ BasysRemotePeerTestCase >> testCreateSyncRequestContext [
 	context := peer createSyncRequestContext.
 
 	context should beInstanceOf: SeamlessSyncRequestContext.
-	context receiverPeer should be: peer.
-	context senderProcess should be: Processor activeProcess
+	context receiverPeer should be: peer
 ]
 
 { #category : #'*Seamless-Tests' }

--- a/Seamless-Tests/BasysRemotePeerTestCase.extension.st
+++ b/Seamless-Tests/BasysRemotePeerTestCase.extension.st
@@ -1,7 +1,16 @@
 Extension { #name : #BasysRemotePeerTestCase }
 
 { #category : #'*Seamless-Tests' }
-BasysRemotePeerTestCase >> testCreationSyncRequestContext [
+BasysRemotePeerTestCase >> testCreateResultDeliveryForRequests [
+
+	| delivery |
+	delivery := peer createResultDeliveryForRequests.
+
+	delivery should beReturnedFrom: [ network createDeliveryForResultFrom: peer ]
+]
+
+{ #category : #'*Seamless-Tests' }
+BasysRemotePeerTestCase >> testCreateSyncRequestContext [
 
 	| context |
 	context := peer createSyncRequestContext.
@@ -12,15 +21,7 @@ BasysRemotePeerTestCase >> testCreationSyncRequestContext [
 ]
 
 { #category : #'*Seamless-Tests' }
-BasysRemotePeerTestCase >> testDestroyedOnRemoteSide [
-
-	peer destroyedOnRemoteSide.
-	
-	network should receive cleanDestroyedPeer: peer
-]
-
-{ #category : #'*Seamless-Tests' }
-BasysRemotePeerTestCase >> testDestroyingShouldAskNetworkForCleanupAfterNotificationRequest [
+BasysRemotePeerTestCase >> testDestroyShouldAskNetworkForCleanupAfterNotificationRequest [
 
 	(peer stub sendDataPacket: Any) willReturnYourself.
 	
@@ -31,7 +32,7 @@ BasysRemotePeerTestCase >> testDestroyingShouldAskNetworkForCleanupAfterNotifica
 ]
 
 { #category : #'*Seamless-Tests' }
-BasysRemotePeerTestCase >> testDestroyingShouldIgnoreConnectionProblemDuringPeerNotification [
+BasysRemotePeerTestCase >> testDestroyShouldIgnoreConnectionProblemDuringPeerNotification [
 
 	(peer stub sendDataPacket: Any) willRaise: ConnectionTimedOut new.
 	
@@ -41,7 +42,7 @@ BasysRemotePeerTestCase >> testDestroyingShouldIgnoreConnectionProblemDuringPeer
 ]
 
 { #category : #'*Seamless-Tests' }
-BasysRemotePeerTestCase >> testDestroyingShouldIgnoreIdentificationFailureDuringPeersNotifications [
+BasysRemotePeerTestCase >> testDestroyShouldIgnoreIdentificationFailureDuringPeersNotifications [
 
 	(peer stub sendDataPacket: Any) willRaise: BasysIdentificationFailed new.
 	
@@ -51,7 +52,7 @@ BasysRemotePeerTestCase >> testDestroyingShouldIgnoreIdentificationFailureDuring
 ]
 
 { #category : #'*Seamless-Tests' }
-BasysRemotePeerTestCase >> testDestroyingShouldIgnoreTimeoutProblemDuringPeersNotifications [
+BasysRemotePeerTestCase >> testDestroyShouldIgnoreTimeoutProblemDuringPeersNotifications [
 
 	(peer stub sendDataPacket: Any) willRaise: OPTimedOutError new.
 	
@@ -61,17 +62,17 @@ BasysRemotePeerTestCase >> testDestroyingShouldIgnoreTimeoutProblemDuringPeersNo
 ]
 
 { #category : #'*Seamless-Tests' }
-BasysRemotePeerTestCase >> testDestroyingShouldSendNotificationRequestToRemoteSide [
+BasysRemotePeerTestCase >> testDestroyShouldSendNotificationRequestToRemoteSide [
 	
-	(peer stub sendDataPacket: Any) willReturnYourself.
+	(peer stub sendDataPacket: Arg request) willReturnYourself.
 	
 	peer destroy.
 		
-	peer should receive sendDataPacket: (Kind of: SeamlessPeerDestroyedRequest).
+	Arg request should beInstanceOf: SeamlessPeerDestroyedRequest
 ]
 
 { #category : #'*Seamless-Tests' }
-BasysRemotePeerTestCase >> testDestroyingShouldSignalUnexpectedProblemsDuringRemoteSideNotifications [
+BasysRemotePeerTestCase >> testDestroyShouldSignalUnexpectedProblemsDuringRemoteSideNotifications [
 
 	| unexpectedProblem |
 	unexpectedProblem := Error new.
@@ -83,7 +84,15 @@ BasysRemotePeerTestCase >> testDestroyingShouldSignalUnexpectedProblemsDuringRem
 ]
 
 { #category : #'*Seamless-Tests' }
-BasysRemotePeerTestCase >> testEvaluationBlockRemotelly [
+BasysRemotePeerTestCase >> testDestroyedOnRemoteSide [
+
+	peer destroyedOnRemoteSide.
+	
+	network should receive cleanDestroyedPeer: peer
+]
+
+{ #category : #'*Seamless-Tests' }
+BasysRemotePeerTestCase >> testEvaluateBlockRemotelly [
 
 	| localBlock |
 	[:context :block |

--- a/Seamless-Tests/SeamlessNetworkTests.class.st
+++ b/Seamless-Tests/SeamlessNetworkTests.class.st
@@ -134,19 +134,7 @@ SeamlessNetworkTests >> testCleanDestroyedPeerWhenItIsOnlyConnectedPeer [
 ]
 
 { #category : #tests }
-SeamlessNetworkTests >> testCreateDeliveryForResultWhenThereIsNoTimeout [
-
-	| delivery |
-	network requestProcessingTimeout: nil.
-	
-	delivery := network createDeliveryForResultFrom: #remotePeer.
-	
-	delivery should beInstanceOf: SeamlessRequestResultDelivery.
-	delivery senderPeer should be: #remotePeer
-]
-
-{ #category : #tests }
-SeamlessNetworkTests >> testCreateDeliveryForResultWhenThereIsTimeout [
+SeamlessNetworkTests >> testCreateDeliveryForResultWhenThereIsConfiguredTimeout [
 
 	| delivery |
 	network requestProcessingTimeout: 10 seconds.
@@ -156,6 +144,31 @@ SeamlessNetworkTests >> testCreateDeliveryForResultWhenThereIsTimeout [
 	delivery should beInstanceOf: SeamlessRequestResultTimelyDelivery.
 	delivery senderPeer should be: #remotePeer.
 	delivery maxTime should equal: 10 seconds
+]
+
+{ #category : #tests }
+SeamlessNetworkTests >> testCreateDeliveryForResultWhenThereIsDefaultTimeout [
+
+	| delivery current |
+	current := SeamlessNetwork defaultRequestProcessingTimeout.
+	[SeamlessNetwork defaultRequestProcessingTimeout: 1000 seconds.
+	delivery := network createDeliveryForResultFrom: #remotePeer.
+	
+	delivery should beInstanceOf: SeamlessRequestResultTimelyDelivery.
+	delivery maxTime should equal: 1000 seconds] 
+		ensure: [ SeamlessNetwork defaultRequestProcessingTimeout: current ]
+]
+
+{ #category : #tests }
+SeamlessNetworkTests >> testCreateDeliveryForResultWhenThereIsNoTimeout [
+
+	| delivery |
+	network requestProcessingTimeout: nil.
+	
+	delivery := network createDeliveryForResultFrom: #remotePeer.
+	
+	delivery should beInstanceOf: SeamlessRequestResultDelivery.
+	delivery senderPeer should be: #remotePeer
 ]
 
 { #category : #tests }
@@ -360,6 +373,18 @@ SeamlessNetworkTests >> testSendingDataPacket [
 		 
 		transporter should receive sendObject: #dataPacket by: connection
 	] runWithMocks 
+]
+
+{ #category : #tests }
+SeamlessNetworkTests >> testShouldFollowDefaultRequestProcessingTimeoutChangesWhenInstanceIsNotConfigured [
+
+	| current |
+	network requestProcessingTimeout should equal: SeamlessNetwork defaultRequestProcessingTimeout.
+	current := SeamlessNetwork defaultRequestProcessingTimeout.
+	[ 
+		SeamlessNetwork defaultRequestProcessingTimeout: 1000 seconds.
+		network requestProcessingTimeout should equal: SeamlessNetwork defaultRequestProcessingTimeout.
+	] ensure: [ SeamlessNetwork defaultRequestProcessingTimeout: current ]
 ]
 
 { #category : #tests }

--- a/Seamless-Tests/SeamlessNetworkTests.class.st
+++ b/Seamless-Tests/SeamlessNetworkTests.class.st
@@ -134,6 +134,29 @@ SeamlessNetworkTests >> testCleanDestroyedPeerWhenItIsOnlyConnectedPeer [
 ]
 
 { #category : #tests }
+SeamlessNetworkTests >> testDefaultResultDeliveryForRequestsWhenThereIsNoTimeout [
+
+	| actual |
+	network requestProcessingTimeout: nil.
+	
+	actual := network defaultResultDeliveryForRequests.
+	
+	actual should beInstanceOf: SeamlessRequestResultDelivery
+]
+
+{ #category : #tests }
+SeamlessNetworkTests >> testDefaultResultDeliveryForRequestsWhenThereIsTimeout [
+
+	| actual |
+	network requestProcessingTimeout: 10 seconds.
+	
+	actual := network defaultResultDeliveryForRequests.
+	
+	actual should beInstanceOf: SeamlessRequestResultTimelyDelivery.
+	actual maxTime should equal: 10 seconds
+]
+
+{ #category : #tests }
 SeamlessNetworkTests >> testDestroying [
 
 	[:peer1 :peer2 |
@@ -256,6 +279,12 @@ SeamlessNetworkTests >> testGettingTransferStrategyWhenItNotSpecifiedForGivenObj
 	actual := network transferStrategyFor: object.
 		
 	actual should beReturnedFrom: [object seamlessDefaultTransferStrategy]
+]
+
+{ #category : #tests }
+SeamlessNetworkTests >> testHasDefaultRequestProcessingTimeoutByDefault [
+
+	network requestProcessingTimeout should equal: SeamlessNetwork defaultRequestProcessingTimeout
 ]
 
 { #category : #tests }

--- a/Seamless-Tests/SeamlessNetworkTests.class.st
+++ b/Seamless-Tests/SeamlessNetworkTests.class.st
@@ -134,26 +134,28 @@ SeamlessNetworkTests >> testCleanDestroyedPeerWhenItIsOnlyConnectedPeer [
 ]
 
 { #category : #tests }
-SeamlessNetworkTests >> testDefaultResultDeliveryForRequestsWhenThereIsNoTimeout [
+SeamlessNetworkTests >> testCreateDeliveryForResultWhenThereIsNoTimeout [
 
-	| actual |
+	| delivery |
 	network requestProcessingTimeout: nil.
 	
-	actual := network defaultResultDeliveryForRequests.
+	delivery := network createDeliveryForResultFrom: #remotePeer.
 	
-	actual should beInstanceOf: SeamlessRequestResultDelivery
+	delivery should beInstanceOf: SeamlessRequestResultDelivery.
+	delivery senderPeer should be: #remotePeer
 ]
 
 { #category : #tests }
-SeamlessNetworkTests >> testDefaultResultDeliveryForRequestsWhenThereIsTimeout [
+SeamlessNetworkTests >> testCreateDeliveryForResultWhenThereIsTimeout [
 
-	| actual |
+	| delivery |
 	network requestProcessingTimeout: 10 seconds.
 	
-	actual := network defaultResultDeliveryForRequests.
+	delivery := network createDeliveryForResultFrom: #remotePeer.
 	
-	actual should beInstanceOf: SeamlessRequestResultTimelyDelivery.
-	actual maxTime should equal: 10 seconds
+	delivery should beInstanceOf: SeamlessRequestResultTimelyDelivery.
+	delivery senderPeer should be: #remotePeer.
+	delivery maxTime should equal: 10 seconds
 ]
 
 { #category : #tests }

--- a/Seamless-Tests/SeamlessPeerIdentificationContextTests.class.st
+++ b/Seamless-Tests/SeamlessPeerIdentificationContextTests.class.st
@@ -13,8 +13,9 @@ SeamlessPeerIdentificationContextTests >> contextClass [
 ]
 
 { #category : #specs }
-SeamlessPeerIdentificationContextTests >> requestSendSpecFor: aSeamlessRequest [
-	^connection sendDataPacket: aSeamlessRequest 
+SeamlessPeerIdentificationContextTests >> contextShouldSend: aSeamlessRequest [
+
+	^connection should takeAWhile to receive sendDataPacket: aSeamlessRequest 
 ]
 
 { #category : #running }
@@ -24,4 +25,10 @@ SeamlessPeerIdentificationContextTests >> setUp [
 	connection := Mock new.
 	
 	context connection: connection
+]
+
+{ #category : #specs }
+SeamlessPeerIdentificationContextTests >> stubRequestDataSend: aSeamlessRequest [
+
+	^connection stub sendDataPacket: aSeamlessRequest 
 ]

--- a/Seamless-Tests/SeamlessRequestResultDeliveryTestCase.class.st
+++ b/Seamless-Tests/SeamlessRequestResultDeliveryTestCase.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : #SeamlessRequestResultDeliveryTestCase,
 	#superclass : #TestCase,
 	#instVars : [
-		'delivery'
+		'delivery',
+		'senderPeer'
 	],
 	#category : #'Seamless-Tests'
 }
@@ -21,15 +22,8 @@ SeamlessRequestResultDeliveryTestCase >> createDelivery [
 SeamlessRequestResultDeliveryTestCase >> setUp [
 	super setUp.
 	
+	senderPeer := Mock new.
 	delivery := self createDelivery
-]
-
-{ #category : #tests }
-SeamlessRequestResultDeliveryTestCase >> testDeliveringGivenResult [
-
-	delivery deliverResult: #result.
-	
-	delivery requestResult should be: #result
 ]
 
 { #category : #tests }
@@ -38,7 +32,7 @@ SeamlessRequestResultDeliveryTestCase >> testDeliveringResultForGivenRequest [
 	| request result resultValue |
 	request := SeamlessMessageSendRequest new.
 	result := Mock new.
-	delivery deliverResult: result.
+	delivery shipResult: result.
 	
 	resultValue := delivery deliverResultFor: request.
 	
@@ -55,7 +49,7 @@ SeamlessRequestResultDeliveryTestCase >> testDeliveringResultForGivenRequestShou
 	receiverProcess := [receiverStarted := true. delivery deliverResultFor: request] fork.
 	[receiverStarted] should takeAWhile to be: true.
 	
-	delivery deliverResult: result.
+	delivery shipResult: result.
 	
 	result should takeAWhile to receive returnValue
 		inProcessWhich should be: receiverProcess
@@ -67,9 +61,17 @@ SeamlessRequestResultDeliveryTestCase >> testDeliveringResultForGivenRequestShou
 	| request result |
 	request := SeamlessMessageSendRequest new.
 	result := Mock new.
-	delivery deliverResult: result.
+	delivery shipResult: result.
 	
 	delivery deliverResultFor: request.
 	
 	request resultBytes should beReturnedFrom: [ result transferredBytes ]
+]
+
+{ #category : #tests }
+SeamlessRequestResultDeliveryTestCase >> testShipingGivenResult [
+
+	delivery shipResult: #result.
+	
+	delivery requestResult should be: #result
 ]

--- a/Seamless-Tests/SeamlessRequestResultDeliveryTestCase.class.st
+++ b/Seamless-Tests/SeamlessRequestResultDeliveryTestCase.class.st
@@ -1,0 +1,75 @@
+Class {
+	#name : #SeamlessRequestResultDeliveryTestCase,
+	#superclass : #TestCase,
+	#instVars : [
+		'delivery'
+	],
+	#category : #'Seamless-Tests'
+}
+
+{ #category : #testing }
+SeamlessRequestResultDeliveryTestCase class >> isAbstract [ 
+	^self = SeamlessRequestResultDeliveryTestCase
+]
+
+{ #category : #running }
+SeamlessRequestResultDeliveryTestCase >> createDelivery [
+	self subclassResponsibility 
+]
+
+{ #category : #running }
+SeamlessRequestResultDeliveryTestCase >> setUp [
+	super setUp.
+	
+	delivery := self createDelivery
+]
+
+{ #category : #tests }
+SeamlessRequestResultDeliveryTestCase >> testDeliveringGivenResult [
+
+	delivery deliverResult: #result.
+	
+	delivery requestResult should be: #result
+]
+
+{ #category : #tests }
+SeamlessRequestResultDeliveryTestCase >> testDeliveringResultForGivenRequest [
+
+	| request result resultValue |
+	request := SeamlessMessageSendRequest new.
+	result := Mock new.
+	delivery deliverResult: result.
+	
+	resultValue := delivery deliverResultFor: request.
+	
+	resultValue should beReturnedFrom: [ result returnValue ]
+]
+
+{ #category : #tests }
+SeamlessRequestResultDeliveryTestCase >> testDeliveringResultForGivenRequestShouldBeSynchronous [
+
+	| request result receiverProcess receiverStarted |
+	request := SeamlessMessageSendRequest new.
+	result := Mock new.
+	
+	receiverProcess := [receiverStarted := true. delivery deliverResultFor: request] fork.
+	[receiverStarted] should takeAWhile to be: true.
+	
+	delivery deliverResult: result.
+	
+	result should takeAWhile to receive returnValue
+		inProcessWhich should be: receiverProcess
+]
+
+{ #category : #tests }
+SeamlessRequestResultDeliveryTestCase >> testDeliveringResultForGivenRequestShouldKeepTransferredBytes [
+
+	| request result |
+	request := SeamlessMessageSendRequest new.
+	result := Mock new.
+	delivery deliverResult: result.
+	
+	delivery deliverResultFor: request.
+	
+	request resultBytes should beReturnedFrom: [ result transferredBytes ]
+]

--- a/Seamless-Tests/SeamlessRequestResultDeliveryTests.class.st
+++ b/Seamless-Tests/SeamlessRequestResultDeliveryTests.class.st
@@ -1,0 +1,65 @@
+Class {
+	#name : #SeamlessRequestResultDeliveryTests,
+	#superclass : #TestCase,
+	#instVars : [
+		'delivery'
+	],
+	#category : #'Seamless-Tests'
+}
+
+{ #category : #running }
+SeamlessRequestResultDeliveryTests >> setUp [
+	super setUp.
+	
+	delivery := SeamlessRequestResultDelivery new
+]
+
+{ #category : #tests }
+SeamlessRequestResultDeliveryTests >> testDeliveringGivenResult [
+
+	delivery deliverResult: #result.
+	
+	delivery requestResult should be: #result
+]
+
+{ #category : #tests }
+SeamlessRequestResultDeliveryTests >> testDeliveringResultForGivenRequest [
+
+	| request result resultValue |
+	request := SeamlessMessageSendRequest new.
+	result := Mock new.
+	delivery deliverResult: result.
+	
+	resultValue := delivery deliverResultFor: request.
+	
+	resultValue should beReturnedFrom: [ result returnValue ]
+]
+
+{ #category : #tests }
+SeamlessRequestResultDeliveryTests >> testDeliveringResultForGivenRequestShouldBeSynchronous [
+
+	| request result receiverProcess receiverStarted |
+	request := SeamlessMessageSendRequest new.
+	result := Mock new.
+	
+	receiverProcess := [receiverStarted := true. delivery deliverResultFor: request] fork.
+	[receiverStarted] should takeAWhile to be: true.
+	
+	delivery deliverResult: result.
+	
+	result should takeAWhile to receive returnValue
+		inProcessWhich should be: receiverProcess
+]
+
+{ #category : #tests }
+SeamlessRequestResultDeliveryTests >> testDeliveringResultForGivenRequestShouldKeepTransferredBytes [
+
+	| request result |
+	request := SeamlessMessageSendRequest new.
+	result := Mock new.
+	delivery deliverResult: result.
+	
+	delivery deliverResultFor: request.
+	
+	request resultBytes should beReturnedFrom: [ result transferredBytes ]
+]

--- a/Seamless-Tests/SeamlessRequestResultDeliveryTests.class.st
+++ b/Seamless-Tests/SeamlessRequestResultDeliveryTests.class.st
@@ -1,65 +1,10 @@
 Class {
 	#name : #SeamlessRequestResultDeliveryTests,
-	#superclass : #TestCase,
-	#instVars : [
-		'delivery'
-	],
+	#superclass : #SeamlessRequestResultDeliveryTestCase,
 	#category : #'Seamless-Tests'
 }
 
 { #category : #running }
-SeamlessRequestResultDeliveryTests >> setUp [
-	super setUp.
-	
-	delivery := SeamlessRequestResultDelivery new
-]
-
-{ #category : #tests }
-SeamlessRequestResultDeliveryTests >> testDeliveringGivenResult [
-
-	delivery deliverResult: #result.
-	
-	delivery requestResult should be: #result
-]
-
-{ #category : #tests }
-SeamlessRequestResultDeliveryTests >> testDeliveringResultForGivenRequest [
-
-	| request result resultValue |
-	request := SeamlessMessageSendRequest new.
-	result := Mock new.
-	delivery deliverResult: result.
-	
-	resultValue := delivery deliverResultFor: request.
-	
-	resultValue should beReturnedFrom: [ result returnValue ]
-]
-
-{ #category : #tests }
-SeamlessRequestResultDeliveryTests >> testDeliveringResultForGivenRequestShouldBeSynchronous [
-
-	| request result receiverProcess receiverStarted |
-	request := SeamlessMessageSendRequest new.
-	result := Mock new.
-	
-	receiverProcess := [receiverStarted := true. delivery deliverResultFor: request] fork.
-	[receiverStarted] should takeAWhile to be: true.
-	
-	delivery deliverResult: result.
-	
-	result should takeAWhile to receive returnValue
-		inProcessWhich should be: receiverProcess
-]
-
-{ #category : #tests }
-SeamlessRequestResultDeliveryTests >> testDeliveringResultForGivenRequestShouldKeepTransferredBytes [
-
-	| request result |
-	request := SeamlessMessageSendRequest new.
-	result := Mock new.
-	delivery deliverResult: result.
-	
-	delivery deliverResultFor: request.
-	
-	request resultBytes should beReturnedFrom: [ result transferredBytes ]
+SeamlessRequestResultDeliveryTests >> createDelivery [
+	^SeamlessRequestResultDelivery new
 ]

--- a/Seamless-Tests/SeamlessRequestResultDeliveryTests.class.st
+++ b/Seamless-Tests/SeamlessRequestResultDeliveryTests.class.st
@@ -6,5 +6,5 @@ Class {
 
 { #category : #running }
 SeamlessRequestResultDeliveryTests >> createDelivery [
-	^SeamlessRequestResultDelivery new
+	^SeamlessRequestResultDelivery from: senderPeer
 ]

--- a/Seamless-Tests/SeamlessRequestResultTimelyDeliveryTests.class.st
+++ b/Seamless-Tests/SeamlessRequestResultTimelyDeliveryTests.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #running }
 SeamlessRequestResultTimelyDeliveryTests >> createDelivery [
-	^SeamlessRequestResultTimelyDelivery maxTime: 10 seconds
+	^SeamlessRequestResultTimelyDelivery from: senderPeer maxTime: 10 seconds
 ]
 
 { #category : #tests }

--- a/Seamless-Tests/SeamlessRequestResultTimelyDeliveryTests.class.st
+++ b/Seamless-Tests/SeamlessRequestResultTimelyDeliveryTests.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #SeamlessRequestResultTimelyDeliveryTests,
+	#superclass : #SeamlessRequestResultDeliveryTestCase,
+	#category : #'Seamless-Tests'
+}
+
+{ #category : #running }
+SeamlessRequestResultTimelyDeliveryTests >> createDelivery [
+	^SeamlessRequestResultTimelyDelivery maxTime: 10 seconds
+]
+
+{ #category : #tests }
+SeamlessRequestResultTimelyDeliveryTests >> testDeliveringResultForGivenRequestShouldFailWhenMaxTimeIsExceeded [
+
+	| request |
+	request := SeamlessMessageSendRequest new.
+	delivery maxTime: 10 milliSeconds.
+	
+	[delivery deliverResultFor: request] should raise: SeamlessRequestTimeout 
+]

--- a/Seamless-Tests/SeamlessRequestSendingContextTestCase.class.st
+++ b/Seamless-Tests/SeamlessRequestSendingContextTestCase.class.st
@@ -2,9 +2,10 @@ Class {
 	#name : #SeamlessRequestSendingContextTestCase,
 	#superclass : #SeamlessRequestContextTestCase,
 	#instVars : [
-		'receiverPeer'
+		'receiverPeer',
+		'network'
 	],
-	#category : 'Seamless-Tests'
+	#category : #'Seamless-Tests'
 }
 
 { #category : #testing }
@@ -16,6 +17,9 @@ SeamlessRequestSendingContextTestCase class >> isAbstract [
 SeamlessRequestSendingContextTestCase >> setUp [
 	super setUp.
 	
+	network := Mock new.
 	receiverPeer := Mock new.
-	context receiverPeer: receiverPeer
+	receiverPeer stub network willReturn: network.
+	 
+	context receiverPeer: receiverPeer.
 ]

--- a/Seamless-Tests/SeamlessSyncRequestContextTests.class.st
+++ b/Seamless-Tests/SeamlessSyncRequestContextTests.class.st
@@ -33,11 +33,11 @@ SeamlessSyncRequestContextTests >> stubRequestDataSend: aSeamlessRequest [
 ]
 
 { #category : #tests }
-SeamlessSyncRequestContextTests >> testHasDefaultResultDeliveryFromNetwork [
+SeamlessSyncRequestContextTests >> testCreatesDeliveryForRequestResult [
 	
 	context receiverPeer: receiverPeer.
 		
-	context resultDelivery should beReturnedFrom: [ network defaultResultDeliveryForRequests ]
+	context resultDelivery should beReturnedFrom: [ receiverPeer createResultDeliveryForRequests ]
 ]
 
 { #category : #tests }

--- a/Seamless-Tests/SeamlessSyncRequestContextTests.class.st
+++ b/Seamless-Tests/SeamlessSyncRequestContextTests.class.st
@@ -1,7 +1,10 @@
 Class {
 	#name : #SeamlessSyncRequestContextTests,
 	#superclass : #SeamlessRequestSendingContextTestCase,
-	#category : 'Seamless-Tests'
+	#instVars : [
+		'resultDelivery'
+	],
+	#category : #'Seamless-Tests'
 }
 
 { #category : #running }
@@ -10,21 +13,30 @@ SeamlessSyncRequestContextTests >> contextClass [
 ]
 
 { #category : #specs }
-SeamlessSyncRequestContextTests >> requestSendSpecFor: aSeamlessRequest [
+SeamlessSyncRequestContextTests >> contextShouldSend: aSeamlessRequest [
 
-	^receiverPeer sendDataPacket: aSeamlessRequest
+	^receiverPeer should takeAWhile to receive sendDataPacket: aSeamlessRequest
+]
+
+{ #category : #running }
+SeamlessSyncRequestContextTests >> setUp [
+	super setUp.
+	
+	resultDelivery := Mock new.
+	context resultDelivery: resultDelivery
+]
+
+{ #category : #specs }
+SeamlessSyncRequestContextTests >> stubRequestDataSend: aSeamlessRequest [
+
+	^receiverPeer stub sendDataPacket: aSeamlessRequest
 ]
 
 { #category : #tests }
-SeamlessSyncRequestContextTests >> testHasActiveProcessAsSenderProcessByDeafult [
+SeamlessSyncRequestContextTests >> testHasResultDeliveryByDefault [
 	
-	context senderProcess should be: Processor activeProcess
-]
-
-{ #category : #tests }
-SeamlessSyncRequestContextTests >> testHasResultWaiterByDefault [
-	
-	context resultWaiter should beInstanceOf: Semaphore
+	context := self contextClass new.
+	context resultDelivery should beInstanceOf: SeamlessRequestResultDelivery 
 ]
 
 { #category : #tests }
@@ -39,34 +51,27 @@ SeamlessSyncRequestContextTests >> testReferenceCreation [
 { #category : #tests }
 SeamlessSyncRequestContextTests >> testReturningResult [
 	
-	[:network :waiterSemaphore |
-		context resultWaiter: waiterSemaphore.
-		waiterSemaphore stub signal when: [ context result ] is: #result.
-		
-		context return: #result.
+	context return: #result.
 
-		waiterSemaphore should receive signal
-	
-	 ] runWithMocks 
+	resultDelivery should receive deliverResult: #result
 ]
 
 { #category : #tests }
 SeamlessSyncRequestContextTests >> testReturningResultShouldRemoveContextFromDistributedObjects [
 	
-	[:network |
-		receiverPeer stub network willReturn: network.
+	| network |
+	network := Mock new.
+	receiverPeer stub network willReturn: network.
 		
-		context return: #result.
+	context return: #result.
 		
-		network should receive removeDistributedObject: context.
-			
-	 ] runWithMocks 
+	network should receive removeDistributedObject: context
 ]
 
 { #category : #tests }
 SeamlessSyncRequestContextTests >> testReturningResultToGivenPeer [
 	
-	context stub return: Any.
+	context stub.
 		
 	context return: #result to: #senderPeer.
 	
@@ -86,47 +91,62 @@ SeamlessSyncRequestContextTests >> testSendingMessage [
 ]
 
 { #category : #tests }
-SeamlessSyncRequestContextTests >> testSendingRequest [
+SeamlessSyncRequestContextTests >> testSendingRequestShouldAssignItToContext [
 	
-	[:request :waiterSemaphore :result |
-		context resultWaiter: waiterSemaphore.		
-		[ (context sendRequest: request) should be: #returnedValue.
-		20 milliSeconds wait ]
-			should strictly satisfy: 
-		[request context: context.
-		 waiterSemaphore wait will: [ context result: result. Processor yield ].
-		(self requestSendSpecFor: request)
-				shouldBeSentInAnotherProcess;
-				when: [ Processor activeProcess priority] is: Processor activeProcess priority.
-		result returnValue willReturn: #returnedValue]	
-	 ] runWithMocks 
+	| request |
+	request := Mock new.
+		
+	context sendRequest: request.
+		
+	request should receive context: context
+]
+
+{ #category : #tests }
+SeamlessSyncRequestContextTests >> testSendingRequestShouldBeDoneAsynchronous [
+	
+	| request |
+	request := Mock new.
+	
+	context sendRequest: request.
+
+	(self contextShouldSend: request) inAnotherProcess
+		inProcessWhich priority should equal: Processor activeProcess priority.
+
+]
+
+{ #category : #tests }
+SeamlessSyncRequestContextTests >> testSendingRequestShouldHoldSenderProcess [
+	
+	| request |
+	request := Mock new.
+		
+	context sendRequest: request.
+		
+	context senderProcess should be: Processor activeProcess
+]
+
+{ #category : #tests }
+SeamlessSyncRequestContextTests >> testSendingRequestShouldReturnResultUsingDelivery [
+	
+	| request |
+	request := Mock new.
+		
+	context sendRequest: request.
+		
+	resultDelivery should receive deliverResultFor: request
 ]
 
 { #category : #tests }
 SeamlessSyncRequestContextTests >> testSendingRequestWhenSendIsFailed [
 	
-	| sendFailure |
-	[:request |
-		sendFailure := Error new.
-		[(self requestSendSpecFor: request) willRaise: sendFailure] should expect.
+	| sendFailure request |
+	request := Mock new.
+	sendFailure := Error new.
+	(self stubRequestDataSend: request) willRaise: sendFailure.
+	resultDelivery stub deliverResult: Arg result.
 		
-		[context sendRequest: request] should raise: sendFailure
-		
-	] runWithMocks 
-]
-
-{ #category : #tests }
-SeamlessSyncRequestContextTests >> testShouldSaveResultBytesInRequest [
+	context sendRequest: request.
 	
-	[:request :waiterSemaphore :result |
-		context resultWaiter: waiterSemaphore.		
-		result stub transferredBytes willReturn: #resultBytes.
-		waiterSemaphore stub wait will: [ context result: result. Processor yield ].
-		
-		context sendRequest: request.
-		20 milliSeconds wait.
-		
-		[ waiterSemaphore wait.
-		request resultBytes: #resultBytes ] should beDoneInOrder 
-	 ] runWithMocks 
+	Arg result should takeAWhile to beInstanceOf: SeamlessThrowExceptionResult.
+	Arg result where exception should be: sendFailure
 ]

--- a/Seamless-Tests/SeamlessSyncRequestContextTests.class.st
+++ b/Seamless-Tests/SeamlessSyncRequestContextTests.class.st
@@ -33,10 +33,11 @@ SeamlessSyncRequestContextTests >> stubRequestDataSend: aSeamlessRequest [
 ]
 
 { #category : #tests }
-SeamlessSyncRequestContextTests >> testHasResultDeliveryByDefault [
+SeamlessSyncRequestContextTests >> testHasDefaultResultDeliveryFromNetwork [
 	
-	context := self contextClass new.
-	context resultDelivery should beInstanceOf: SeamlessRequestResultDelivery 
+	context receiverPeer: receiverPeer.
+		
+	context resultDelivery should beReturnedFrom: [ network defaultResultDeliveryForRequests ]
 ]
 
 { #category : #tests }
@@ -58,11 +59,7 @@ SeamlessSyncRequestContextTests >> testReturningResult [
 
 { #category : #tests }
 SeamlessSyncRequestContextTests >> testReturningResultShouldRemoveContextFromDistributedObjects [
-	
-	| network |
-	network := Mock new.
-	receiverPeer stub network willReturn: network.
-		
+			
 	context return: #result.
 		
 	network should receive removeDistributedObject: context

--- a/Seamless-Tests/SeamlessSyncRequestContextTests.class.st
+++ b/Seamless-Tests/SeamlessSyncRequestContextTests.class.st
@@ -54,7 +54,7 @@ SeamlessSyncRequestContextTests >> testReturningResult [
 	
 	context return: #result.
 
-	resultDelivery should receive deliverResult: #result
+	resultDelivery should receive shipResult: #result
 ]
 
 { #category : #tests }
@@ -140,7 +140,7 @@ SeamlessSyncRequestContextTests >> testSendingRequestWhenSendIsFailed [
 	request := Mock new.
 	sendFailure := Error new.
 	(self stubRequestDataSend: request) willRaise: sendFailure.
-	resultDelivery stub deliverResult: Arg result.
+	resultDelivery stub shipResult: Arg result.
 		
 	context sendRequest: request.
 	

--- a/Seamless/BasysRemotePeer.extension.st
+++ b/Seamless/BasysRemotePeer.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : #BasysRemotePeer }
 
 { #category : #'*Seamless' }
+BasysRemotePeer >> createResultDeliveryForRequests [
+
+	^network createDeliveryForResultFrom: self
+]
+
+{ #category : #'*Seamless' }
 BasysRemotePeer >> createSyncRequestContext [
 
 	^SeamlessSyncRequestContext receiverPeer: self

--- a/Seamless/SeamlessNetwork.class.st
+++ b/Seamless/SeamlessNetwork.class.st
@@ -81,6 +81,34 @@ SeamlessNetwork class >> defaultRequestProcessingTimeout: aDuration [
 	defaultRequestProcessingTimeout := aDuration
 ]
 
+{ #category : #settings }
+SeamlessNetwork class >> defaultRequestProcessingTimeoutSecs [
+	^self defaultRequestProcessingTimeout ifNil: [ 0 ] ifNotNil: [:timeout | timeout asSeconds]
+]
+
+{ #category : #settings }
+SeamlessNetwork class >> defaultRequestProcessingTimeoutSecs: aNumber [
+
+	| timeout |
+	timeout := (aNumber isNil or: [aNumber isZero]) 
+					ifTrue: [ nil ] ifFalse: [ aNumber seconds].
+	self defaultRequestProcessingTimeout: timeout
+]
+
+{ #category : #settings }
+SeamlessNetwork class >> settingOn: aBuilder [
+	<systemsettings>
+	(aBuilder group: #seamless)
+		label: 'Seamless';
+		parent: #tools;
+		description: 'Seamless network settings';
+		with: [ (aBuilder setting: #defaultRequestProcessingTimeoutSecs)
+				target: self; 
+				label: 'Default request processing timeout (secs)';
+				default: 0
+				] 
+]
+
 { #category : #accessing }
 SeamlessNetwork >> addTransferStrategy: aTransferStrategy [
 
@@ -154,7 +182,6 @@ SeamlessNetwork >> initialize [
 	distributedObjects := SeamlessDistributedObjects over: self.
 	transferStrategies := SortedCollection sortBlock: [:a :b | a priority >= b priority].
 	transport := SeamlessObjectTransporter default.
-	connectionTimeout := 10 seconds.
 	requestProcessingTimeout := self class defaultRequestProcessingTimeout
 ]
 
@@ -213,8 +240,8 @@ SeamlessNetwork >> requestProcessingTimeout [
 ]
 
 { #category : #accessing }
-SeamlessNetwork >> requestProcessingTimeout: anObject [
-	requestProcessingTimeout := anObject
+SeamlessNetwork >> requestProcessingTimeout: aDuration [
+	requestProcessingTimeout := aDuration
 ]
 
 { #category : #operations }

--- a/Seamless/SeamlessNetwork.class.st
+++ b/Seamless/SeamlessNetwork.class.st
@@ -132,10 +132,9 @@ SeamlessNetwork >> cleanDestroyedPeer: aRemotePeer [
 
 { #category : #accessing }
 SeamlessNetwork >> createDeliveryForResultFrom: aRemotePeer [
-	^ requestProcessingTimeout 
+	^ self requestProcessingTimeout
 			ifNil: [SeamlessRequestResultDelivery from: aRemotePeer]
-			ifNotNil: [ 	SeamlessRequestResultTimelyDelivery 
-								from: aRemotePeer maxTime: requestProcessingTimeout  ]
+			ifNotNil: [:timeout |	SeamlessRequestResultTimelyDelivery from: aRemotePeer maxTime: timeout]
 ]
 
 { #category : #controlling }
@@ -181,8 +180,7 @@ SeamlessNetwork >> initialize [
 	
 	distributedObjects := SeamlessDistributedObjects over: self.
 	transferStrategies := SortedCollection sortBlock: [:a :b | a priority >= b priority].
-	transport := SeamlessObjectTransporter default.
-	requestProcessingTimeout := self class defaultRequestProcessingTimeout
+	transport := SeamlessObjectTransporter default
 ]
 
 { #category : #accessing }
@@ -236,7 +234,7 @@ SeamlessNetwork >> removeDistributedObject: anObject [
 
 { #category : #accessing }
 SeamlessNetwork >> requestProcessingTimeout [
-	^ requestProcessingTimeout
+	^ requestProcessingTimeout ifNil: [self class defaultRequestProcessingTimeout]
 ]
 
 { #category : #accessing }

--- a/Seamless/SeamlessNetwork.class.st
+++ b/Seamless/SeamlessNetwork.class.st
@@ -110,13 +110,6 @@ SeamlessNetwork >> createDeliveryForResultFrom: aRemotePeer [
 								from: aRemotePeer maxTime: requestProcessingTimeout  ]
 ]
 
-{ #category : #accessing }
-SeamlessNetwork >> defaultResultDeliveryForRequests [
-	^ requestProcessingTimeout 
-			ifNil: [SeamlessRequestResultDelivery new]
-			ifNotNil: [ SeamlessRequestResultTimelyDelivery maxTime: requestProcessingTimeout  ]
-]
-
 { #category : #controlling }
 SeamlessNetwork >> destroy [
 	"This methods supposed to be used when you really want to destroy local peer network and release all resources without thinking that they can be in use on remote peers.

--- a/Seamless/SeamlessNetwork.class.st
+++ b/Seamless/SeamlessNetwork.class.st
@@ -62,10 +62,24 @@ Class {
 	#instVars : [
 		'distributedObjects',
 		'transferStrategies',
-		'transport'
+		'transport',
+		'requestProcessingTimeout'
 	],
-	#category : 'Seamless-Core'
+	#classInstVars : [
+		'defaultRequestProcessingTimeout'
+	],
+	#category : #'Seamless-Core'
 }
+
+{ #category : #accessing }
+SeamlessNetwork class >> defaultRequestProcessingTimeout [
+	^defaultRequestProcessingTimeout
+]
+
+{ #category : #accessing }
+SeamlessNetwork class >> defaultRequestProcessingTimeout: aDuration [
+	defaultRequestProcessingTimeout := aDuration
+]
 
 { #category : #accessing }
 SeamlessNetwork >> addTransferStrategy: aTransferStrategy [
@@ -86,6 +100,13 @@ SeamlessNetwork >> cleanDestroyedPeer: aRemotePeer [
 	distributedObjects removeObjectsDistributedBy: aRemotePeer.
 	remotePeers remove: aRemotePeer ifAbsent: [].
 	remotePeers ifEmpty: [ distributedObjects clear ]
+]
+
+{ #category : #accessing }
+SeamlessNetwork >> defaultResultDeliveryForRequests [
+	^ requestProcessingTimeout 
+			ifNil: [SeamlessRequestResultDelivery new]
+			ifNotNil: [ SeamlessRequestResultTimelyDelivery maxTime: requestProcessingTimeout  ]
 ]
 
 { #category : #controlling }
@@ -133,6 +154,7 @@ SeamlessNetwork >> initialize [
 	transferStrategies := SortedCollection sortBlock: [:a :b | a priority >= b priority].
 	transport := SeamlessObjectTransporter default.
 	connectionTimeout := 10 seconds.
+	requestProcessingTimeout := self class defaultRequestProcessingTimeout
 ]
 
 { #category : #accessing }
@@ -182,6 +204,16 @@ SeamlessNetwork >> referenceFor: anObject ifNewUse: refCreationBlock [
 SeamlessNetwork >> removeDistributedObject: anObject [
 
 	distributedObjects remove: anObject
+]
+
+{ #category : #accessing }
+SeamlessNetwork >> requestProcessingTimeout [
+	^ requestProcessingTimeout
+]
+
+{ #category : #accessing }
+SeamlessNetwork >> requestProcessingTimeout: anObject [
+	requestProcessingTimeout := anObject
 ]
 
 { #category : #operations }

--- a/Seamless/SeamlessNetwork.class.st
+++ b/Seamless/SeamlessNetwork.class.st
@@ -103,6 +103,14 @@ SeamlessNetwork >> cleanDestroyedPeer: aRemotePeer [
 ]
 
 { #category : #accessing }
+SeamlessNetwork >> createDeliveryForResultFrom: aRemotePeer [
+	^ requestProcessingTimeout 
+			ifNil: [SeamlessRequestResultDelivery from: aRemotePeer]
+			ifNotNil: [ 	SeamlessRequestResultTimelyDelivery 
+								from: aRemotePeer maxTime: requestProcessingTimeout  ]
+]
+
+{ #category : #accessing }
 SeamlessNetwork >> defaultResultDeliveryForRequests [
 	^ requestProcessingTimeout 
 			ifNil: [SeamlessRequestResultDelivery new]

--- a/Seamless/SeamlessRequestResultDelivery.class.st
+++ b/Seamless/SeamlessRequestResultDelivery.class.st
@@ -23,11 +23,18 @@ Class {
 	#name : #SeamlessRequestResultDelivery,
 	#superclass : #Object,
 	#instVars : [
+		'senderPeer',
 		'synchronizationSemaphore',
 		'requestResult'
 	],
 	#category : #'Seamless-Requests'
 }
+
+{ #category : #'instance creation' }
+SeamlessRequestResultDelivery class >> from: aRemotePeer [
+	^self new 
+		senderPeer: aRemotePeer
+]
 
 { #category : #delivery }
 SeamlessRequestResultDelivery >> deliverResult: aRequestResult [
@@ -56,6 +63,16 @@ SeamlessRequestResultDelivery >> initialize [
 { #category : #accessing }
 SeamlessRequestResultDelivery >> requestResult [
 	^ requestResult
+]
+
+{ #category : #accessing }
+SeamlessRequestResultDelivery >> senderPeer [
+	^ senderPeer
+]
+
+{ #category : #accessing }
+SeamlessRequestResultDelivery >> senderPeer: anObject [
+	senderPeer := anObject
 ]
 
 { #category : #private }

--- a/Seamless/SeamlessRequestResultDelivery.class.st
+++ b/Seamless/SeamlessRequestResultDelivery.class.st
@@ -3,7 +3,7 @@ I am a helper object to manage a delivery of result inside SeamlessSyncRequestCo
 
 From the one side users which need a result should ask me for:
 
-	delivery deliverResultTo: aRequest
+	delivery deliverResultFor: aRequest
 	
 which will wait until the result will be finally delivered. When it will happen I will return actual result value from this method. aRequest will receive transferredBytes for statistics. 
 
@@ -29,17 +29,17 @@ Class {
 	#category : #'Seamless-Requests'
 }
 
-{ #category : #execution }
+{ #category : #delivery }
 SeamlessRequestResultDelivery >> deliverResult: aRequestResult [
 
 	requestResult := aRequestResult.
 	synchronizationSemaphore signal
 ]
 
-{ #category : #execution }
+{ #category : #delivery }
 SeamlessRequestResultDelivery >> deliverResultFor: aRequest [
 
-	synchronizationSemaphore wait.
+	self waitResult.
 	
 	aRequest resultBytes: requestResult transferredBytes.
 	
@@ -58,17 +58,7 @@ SeamlessRequestResultDelivery >> requestResult [
 	^ requestResult
 ]
 
-{ #category : #accessing }
-SeamlessRequestResultDelivery >> requestResult: anObject [
-	requestResult := anObject
-]
-
-{ #category : #accessing }
-SeamlessRequestResultDelivery >> synchronizationSemaphore [
-	^ synchronizationSemaphore
-]
-
-{ #category : #accessing }
-SeamlessRequestResultDelivery >> synchronizationSemaphore: anObject [
-	synchronizationSemaphore := anObject
+{ #category : #private }
+SeamlessRequestResultDelivery >> waitResult [
+	synchronizationSemaphore wait
 ]

--- a/Seamless/SeamlessRequestResultDelivery.class.st
+++ b/Seamless/SeamlessRequestResultDelivery.class.st
@@ -1,5 +1,5 @@
 "
-I am a helper object to manage a delivery of result inside SeamlessSyncRequestContext.
+I am a helper object to manage the delivery of result inside SeamlessSyncRequestContext.
 
 From the one side users which need a result should ask me for:
 
@@ -7,15 +7,20 @@ From the one side users which need a result should ask me for:
 	
 which will wait until the result will be finally delivered. When it will happen I will return actual result value from this method. aRequest will receive transferredBytes for statistics. 
 
-From the other side users which have a result should send it through me using: 
+From the other side users which have a result should ship it through me using: 
 
-	deliver deliverResult: aRequestResult 
+	deliver shipResult: aRequestResult 
 	
 where I will signal all waiting users that the result is ready using my synchronizationSemaphore.
+
+My instances are created with remote peer instance, #senderPeer, which is supposed to send the result as the response to received request:
+
+	SeamlessRequestResultDelivery from: aRemotePeer
 
 Internal Representation and Key Implementation Points.
 
     Instance Variables
+	senderPeer:		<BasysRemotePeer>
 	requestResult:		<SeamlessRequestResult>
 	synchronizationSemaphore:		<Semaphore>
 "
@@ -34,13 +39,6 @@ Class {
 SeamlessRequestResultDelivery class >> from: aRemotePeer [
 	^self new 
 		senderPeer: aRemotePeer
-]
-
-{ #category : #delivery }
-SeamlessRequestResultDelivery >> deliverResult: aRequestResult [
-
-	requestResult := aRequestResult.
-	synchronizationSemaphore signal
 ]
 
 { #category : #delivery }
@@ -73,6 +71,13 @@ SeamlessRequestResultDelivery >> senderPeer [
 { #category : #accessing }
 SeamlessRequestResultDelivery >> senderPeer: anObject [
 	senderPeer := anObject
+]
+
+{ #category : #delivery }
+SeamlessRequestResultDelivery >> shipResult: aRequestResult [
+
+	requestResult := aRequestResult.
+	synchronizationSemaphore signal
 ]
 
 { #category : #private }

--- a/Seamless/SeamlessRequestResultDelivery.class.st
+++ b/Seamless/SeamlessRequestResultDelivery.class.st
@@ -1,0 +1,74 @@
+"
+I am a helper object to manage a delivery of result inside SeamlessSyncRequestContext.
+
+From the one side users which need a result should ask me for:
+
+	delivery deliverResultTo: aRequest
+	
+which will wait until the result will be finally delivered. When it will happen I will return actual result value from this method. aRequest will receive transferredBytes for statistics. 
+
+From the other side users which have a result should send it through me using: 
+
+	deliver deliverResult: aRequestResult 
+	
+where I will signal all waiting users that the result is ready using my synchronizationSemaphore.
+
+Internal Representation and Key Implementation Points.
+
+    Instance Variables
+	requestResult:		<SeamlessRequestResult>
+	synchronizationSemaphore:		<Semaphore>
+"
+Class {
+	#name : #SeamlessRequestResultDelivery,
+	#superclass : #Object,
+	#instVars : [
+		'synchronizationSemaphore',
+		'requestResult'
+	],
+	#category : #'Seamless-Requests'
+}
+
+{ #category : #execution }
+SeamlessRequestResultDelivery >> deliverResult: aRequestResult [
+
+	requestResult := aRequestResult.
+	synchronizationSemaphore signal
+]
+
+{ #category : #execution }
+SeamlessRequestResultDelivery >> deliverResultFor: aRequest [
+
+	synchronizationSemaphore wait.
+	
+	aRequest resultBytes: requestResult transferredBytes.
+	
+	^requestResult returnValue
+]
+
+{ #category : #initialization }
+SeamlessRequestResultDelivery >> initialize [
+	super initialize.
+	
+	synchronizationSemaphore := Semaphore new
+]
+
+{ #category : #accessing }
+SeamlessRequestResultDelivery >> requestResult [
+	^ requestResult
+]
+
+{ #category : #accessing }
+SeamlessRequestResultDelivery >> requestResult: anObject [
+	requestResult := anObject
+]
+
+{ #category : #accessing }
+SeamlessRequestResultDelivery >> synchronizationSemaphore [
+	^ synchronizationSemaphore
+]
+
+{ #category : #accessing }
+SeamlessRequestResultDelivery >> synchronizationSemaphore: anObject [
+	synchronizationSemaphore := anObject
+]

--- a/Seamless/SeamlessRequestResultTimelyDelivery.class.st
+++ b/Seamless/SeamlessRequestResultTimelyDelivery.class.st
@@ -1,5 +1,5 @@
 "
-I represent a delivery of request results which restricted in time using specified timeout, #maxTime.
+I represent a result delivery restricted in time using specified timeout, #maxTime.
  
 Internal Representation and Key Implementation Points.
 
@@ -18,12 +18,6 @@ Class {
 { #category : #'instance creation' }
 SeamlessRequestResultTimelyDelivery class >> from: aRemotePeer maxTime: aDuration [
 	^(self from: aRemotePeer)
-		maxTime: aDuration
-]
-
-{ #category : #'instance creation' }
-SeamlessRequestResultTimelyDelivery class >> maxTime: aDuration [
-	^self new 
 		maxTime: aDuration
 ]
 

--- a/Seamless/SeamlessRequestResultTimelyDelivery.class.st
+++ b/Seamless/SeamlessRequestResultTimelyDelivery.class.st
@@ -16,6 +16,12 @@ Class {
 }
 
 { #category : #'instance creation' }
+SeamlessRequestResultTimelyDelivery class >> from: aRemotePeer maxTime: aDuration [
+	^(self from: aRemotePeer)
+		maxTime: aDuration
+]
+
+{ #category : #'instance creation' }
 SeamlessRequestResultTimelyDelivery class >> maxTime: aDuration [
 	^self new 
 		maxTime: aDuration

--- a/Seamless/SeamlessRequestResultTimelyDelivery.class.st
+++ b/Seamless/SeamlessRequestResultTimelyDelivery.class.st
@@ -1,0 +1,39 @@
+"
+I represent a delivery of request results which restricted in time using specified timeout, #maxTime.
+ 
+Internal Representation and Key Implementation Points.
+
+    Instance Variables
+	maxTime:		<Duration>
+"
+Class {
+	#name : #SeamlessRequestResultTimelyDelivery,
+	#superclass : #SeamlessRequestResultDelivery,
+	#instVars : [
+		'maxTime'
+	],
+	#category : #'Seamless-Requests'
+}
+
+{ #category : #'instance creation' }
+SeamlessRequestResultTimelyDelivery class >> maxTime: aDuration [
+	^self new 
+		maxTime: aDuration
+]
+
+{ #category : #accessing }
+SeamlessRequestResultTimelyDelivery >> maxTime [
+	^ maxTime
+]
+
+{ #category : #accessing }
+SeamlessRequestResultTimelyDelivery >> maxTime: anObject [
+	maxTime := anObject
+]
+
+{ #category : #private }
+SeamlessRequestResultTimelyDelivery >> waitResult [
+	| timeout |
+	timeout := synchronizationSemaphore wait: maxTime.
+	timeout ifTrue: [ SeamlessRequestTimeout signal ]
+]

--- a/Seamless/SeamlessRequestTimeout.class.st
+++ b/Seamless/SeamlessRequestTimeout.class.st
@@ -1,0 +1,8 @@
+"
+I represent a timeout error when request processing took too much time or in other words when result was not delivered during specified maximum time 
+"
+Class {
+	#name : #SeamlessRequestTimeout,
+	#superclass : #Error,
+	#category : #'Seamless-Requests'
+}

--- a/Seamless/SeamlessSyncRequestContext.class.st
+++ b/Seamless/SeamlessSyncRequestContext.class.st
@@ -36,16 +36,15 @@ SeamlessSyncRequestContext >> forkProcessingOf: aSeamlessRequest [
 	] forkAt: Processor activePriority named: 'Seamless request sending'
 ]
 
-{ #category : #initialization }
-SeamlessSyncRequestContext >> initialize [
-	super initialize.
-	
-	resultDelivery := SeamlessRequestResultDelivery new
-]
-
 { #category : #private }
 SeamlessSyncRequestContext >> performRequestSend: aSeamlessRequest [
 	receiverPeer sendDataPacket: aSeamlessRequest 
+]
+
+{ #category : #accessing }
+SeamlessSyncRequestContext >> receiverPeer: anObject [
+	super receiverPeer: anObject.
+	resultDelivery := self network defaultResultDeliveryForRequests
 ]
 
 { #category : #accessing }

--- a/Seamless/SeamlessSyncRequestContext.class.st
+++ b/Seamless/SeamlessSyncRequestContext.class.st
@@ -44,7 +44,7 @@ SeamlessSyncRequestContext >> performRequestSend: aSeamlessRequest [
 { #category : #accessing }
 SeamlessSyncRequestContext >> receiverPeer: anObject [
 	super receiverPeer: anObject.
-	resultDelivery := self network defaultResultDeliveryForRequests
+	resultDelivery := receiverPeer createResultDeliveryForRequests 
 ]
 
 { #category : #accessing }

--- a/Seamless/SeamlessSyncRequestContext.class.st
+++ b/Seamless/SeamlessSyncRequestContext.class.st
@@ -60,7 +60,7 @@ SeamlessSyncRequestContext >> resultDelivery: anObject [
 { #category : #operations }
 SeamlessSyncRequestContext >> return: aSeamlessRequestResult [
 
-	resultDelivery deliverResult: aSeamlessRequestResult.
+	resultDelivery shipResult: aSeamlessRequestResult.
 	
 	self network removeDistributedObject: self
 ]

--- a/Seamless/SeamlessSyncRequestContext.class.st
+++ b/Seamless/SeamlessSyncRequestContext.class.st
@@ -16,8 +16,6 @@ Class {
 	#superclass : #SeamlessRequestSendingContext,
 	#instVars : [
 		'senderProcess',
-		'resultWaiter',
-		'result',
 		'resultDelivery'
 	],
 	#category : #'Seamless-Requests'
@@ -51,16 +49,6 @@ SeamlessSyncRequestContext >> performRequestSend: aSeamlessRequest [
 ]
 
 { #category : #accessing }
-SeamlessSyncRequestContext >> result [
-	^ result
-]
-
-{ #category : #accessing }
-SeamlessSyncRequestContext >> result: anObject [
-	result := anObject
-]
-
-{ #category : #accessing }
 SeamlessSyncRequestContext >> resultDelivery [
 	^ resultDelivery
 ]
@@ -68,16 +56,6 @@ SeamlessSyncRequestContext >> resultDelivery [
 { #category : #accessing }
 SeamlessSyncRequestContext >> resultDelivery: anObject [
 	resultDelivery := anObject
-]
-
-{ #category : #accessing }
-SeamlessSyncRequestContext >> resultWaiter [
-	^ resultWaiter
-]
-
-{ #category : #accessing }
-SeamlessSyncRequestContext >> resultWaiter: anObject [
-	resultWaiter := anObject
 ]
 
 { #category : #operations }

--- a/Seamless/SeamlessSyncRequestContext.class.st
+++ b/Seamless/SeamlessSyncRequestContext.class.st
@@ -17,9 +17,10 @@ Class {
 	#instVars : [
 		'senderProcess',
 		'resultWaiter',
-		'result'
+		'result',
+		'resultDelivery'
 	],
-	#category : 'Seamless-Requests'
+	#category : #'Seamless-Requests'
 }
 
 { #category : #accessing }
@@ -41,8 +42,7 @@ SeamlessSyncRequestContext >> forkProcessingOf: aSeamlessRequest [
 SeamlessSyncRequestContext >> initialize [
 	super initialize.
 	
-	resultWaiter := Semaphore new.
-	senderProcess := Processor activeProcess
+	resultDelivery := SeamlessRequestResultDelivery new
 ]
 
 { #category : #private }
@@ -61,6 +61,16 @@ SeamlessSyncRequestContext >> result: anObject [
 ]
 
 { #category : #accessing }
+SeamlessSyncRequestContext >> resultDelivery [
+	^ resultDelivery
+]
+
+{ #category : #accessing }
+SeamlessSyncRequestContext >> resultDelivery: anObject [
+	resultDelivery := anObject
+]
+
+{ #category : #accessing }
 SeamlessSyncRequestContext >> resultWaiter [
 	^ resultWaiter
 ]
@@ -73,9 +83,7 @@ SeamlessSyncRequestContext >> resultWaiter: anObject [
 { #category : #operations }
 SeamlessSyncRequestContext >> return: aSeamlessRequestResult [
 
-	result := aSeamlessRequestResult.
-
-	resultWaiter signal.
+	resultDelivery deliverResult: aSeamlessRequestResult.
 	
 	self network removeDistributedObject: self
 ]
@@ -90,15 +98,11 @@ SeamlessSyncRequestContext >> sendMessage: aMessageSend [
 SeamlessSyncRequestContext >> sendRequest: aSeamlessRequest [ 
 
 	aSeamlessRequest context: self.
+	senderProcess := Processor activeProcess.
 	
 	self forkProcessingOf: aSeamlessRequest.
 
-	resultWaiter wait.
-	
-	"Here we fix data statistics about request execution"
-	aSeamlessRequest resultBytes: result transferredBytes.
-	
-	^result returnValue
+	^resultDelivery deliverResultFor: aSeamlessRequest
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- Network can be configured with #requestProcessingTimeout- The default value is defined on class side as #defaultRequestProcessingTimeout (nil by default)Internally SeamlessSynchRequestContext was refactored: SeamlessRequestResultDelivery was extracted with semaphore synchronization logic. For timeout behavior special subclass of delivery was implemented,  SeamlessRequestResultTimelyDelivery