### PR TITLE
Simplify request send logic

### DIFF
--- a/Seamless-Tests/SeamlessPeerIdentificationContextTests.class.st
+++ b/Seamless-Tests/SeamlessPeerIdentificationContextTests.class.st
@@ -15,7 +15,7 @@ SeamlessPeerIdentificationContextTests >> contextClass [
 { #category : #specs }
 SeamlessPeerIdentificationContextTests >> contextShouldSend: aSeamlessRequest [
 
-	^connection should takeAWhile to receive sendDataPacket: aSeamlessRequest 
+	^connection should receive sendDataPacket: aSeamlessRequest 
 ]
 
 { #category : #running }

--- a/Seamless-Tests/SeamlessSyncRequestContextTests.class.st
+++ b/Seamless-Tests/SeamlessSyncRequestContextTests.class.st
@@ -15,7 +15,7 @@ SeamlessSyncRequestContextTests >> contextClass [
 { #category : #specs }
 SeamlessSyncRequestContextTests >> contextShouldSend: aSeamlessRequest [
 
-	^receiverPeer should takeAWhile to receive sendDataPacket: aSeamlessRequest
+	^receiverPeer should receive sendDataPacket: aSeamlessRequest
 ]
 
 { #category : #running }
@@ -88,6 +88,17 @@ SeamlessSyncRequestContextTests >> testSendingMessage [
 ]
 
 { #category : #tests }
+SeamlessSyncRequestContextTests >> testSendingRequest [
+	
+	| request |
+	request := Mock new.
+	
+	context sendRequest: request.
+
+	self contextShouldSend: request
+]
+
+{ #category : #tests }
 SeamlessSyncRequestContextTests >> testSendingRequestShouldAssignItToContext [
 	
 	| request |
@@ -96,19 +107,6 @@ SeamlessSyncRequestContextTests >> testSendingRequestShouldAssignItToContext [
 	context sendRequest: request.
 		
 	request should receive context: context
-]
-
-{ #category : #tests }
-SeamlessSyncRequestContextTests >> testSendingRequestShouldBeDoneAsynchronous [
-	
-	| request |
-	request := Mock new.
-	
-	context sendRequest: request.
-
-	(self contextShouldSend: request) inAnotherProcess
-		inProcessWhich priority should equal: Processor activeProcess priority.
-
 ]
 
 { #category : #tests }
@@ -140,10 +138,6 @@ SeamlessSyncRequestContextTests >> testSendingRequestWhenSendIsFailed [
 	request := Mock new.
 	sendFailure := Error new.
 	(self stubRequestDataSend: request) willRaise: sendFailure.
-	resultDelivery stub shipResult: Arg result.
 		
-	context sendRequest: request.
-	
-	Arg result should takeAWhile to beInstanceOf: SeamlessThrowExceptionResult.
-	Arg result where exception should be: sendFailure
+	[context sendRequest: request] should raise: sendFailure
 ]

--- a/Seamless/SeamlessSyncRequestContext.class.st
+++ b/Seamless/SeamlessSyncRequestContext.class.st
@@ -1,15 +1,15 @@
 "
 I am request context which implements synchronous request sending when senders are waiting result from receiver peer.
-To implement this behaviour I fork actual request sending and wait signal from resultWaiter semaphore. I am transfered by reference to receiver peer as part of sent request. On receiver side request executed and result is returned to me by ""backward"" remote message. I receive #return: message which stores argument as result and signal resultWaiter semaphore. Signal resumes original sender process which continue execution with received value.
+To implement this behaviour send a request to receiver peer and wait a delivery of result from it. 
+I am transfered by reference to receiver peer as part of sent request. On receiver side request executed and result is returned to me by SeamlessDeliverResultRequest using same context. At the end I receive #return: message which shifts the argument to the result delivery. Delivery signals the original sender process which continue execution with received value.
 
-During request execution receiver peer will keep reference to me. It can be used to retrieved information on receiver side about my sender process. 
+During request execution the receiver peer will keep reference to me. It can be used to retrieved information on receiver side about my sender process. 
  
 Internal Representation and Key Implementation Points.
 
     Instance Variables
-	result:		<SeamlessRequestResult>
-	resultWaiter:		<Semaphore>
 	senderProcess:		<Process>
+	resultDelivery		<SeamlessRequestResultDelivery>
 "
 Class {
 	#name : #SeamlessSyncRequestContext,
@@ -24,16 +24,6 @@ Class {
 { #category : #accessing }
 SeamlessSyncRequestContext >> createSeamlessReference [
 	^SeamlessRequestContextReference new
-]
-
-{ #category : #private }
-SeamlessSyncRequestContext >> forkProcessingOf: aSeamlessRequest [
-
-	[ 
-		[self performRequestSend: aSeamlessRequest] on: Error do: [ :err |
-			self return:  (SeamlessThrowExceptionResult with: err) ]
-	
-	] forkAt: Processor activePriority named: 'Seamless request sending'
 ]
 
 { #category : #private }
@@ -77,7 +67,7 @@ SeamlessSyncRequestContext >> sendRequest: aSeamlessRequest [
 	aSeamlessRequest context: self.
 	senderProcess := Processor activeProcess.
 	
-	self forkProcessingOf: aSeamlessRequest.
+	self performRequestSend: aSeamlessRequest.
 
 	^resultDelivery deliverResultFor: aSeamlessRequest
 ]


### PR DESCRIPTION
It removes fork logic to send a request by context. It was definitely redundant and now code is simpler. 
In addition it makes processing timeout to be independent (do not include) from connecting time.