### PR TITLE
Pharo9 compatibility

### DIFF
--- a/Seamless-GTSupport/SeamlessRemoteClassScope.class.st
+++ b/Seamless-GTSupport/SeamlessRemoteClassScope.class.st
@@ -1,14 +1,19 @@
 Class {
 	#name : #SeamlessRemoteClassScope,
 	#superclass : #OCClassScope,
-	#category : 'Seamless-GTSupport'
+	#category : #'Seamless-GTSupport'
 }
 
 { #category : #lookup }
 SeamlessRemoteClassScope >> lookupVar: name [
 	"Return a SemVar for my pool var with this name.  Return nil if none found"
+	| ocClass |
 	^(class bindingOf: name asSymbol) ifNotNil: [:assoc | 
-		OCLiteralVariable new 
+		"Compatibility with Pharo 9 where all variables were unified under single Variable hierarchy"
+		(self class environment hasClassNamed: #OCLiteralVariable) ifFalse: [ ^assoc ].
+		ocClass := self class environment classNamed: #OCLiteralVariable.
+		ocClass isDeprecated ifTrue: [ ^ assoc ].
+		ocClass new 
 			assoc: assoc; 
 			scope: self; 
 			yourself]

--- a/Seamless/CompiledBlock.extension.st
+++ b/Seamless/CompiledBlock.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #CompiledBlock }
+
+{ #category : #'*Seamless' }
+CompiledBlock >> isOnlyDefaultTransferStrategyAllowed [
+	"CompiledBlock is an essential part of CompiledMethod with strong requirements from the VM.
+	So it must be always transferred by value"	
+	^true
+]
+
+{ #category : #'*Seamless' }
+CompiledBlock >> seamlessDefaultTransferStrategy [
+	"CompiledBlock is an essential part of CompiledMethod with strong requirements from the VM.
+	So it must be always transferred by value"
+	^SeamlessTransferStrategy defaultByValue
+]

--- a/Seamless/CompiledCode.extension.st
+++ b/Seamless/CompiledCode.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #CompiledCode }
+
+{ #category : #'*Seamless' }
+CompiledCode >> prepareValueTransferBy: aSeamlessTransporter [
+
+	self literalsDo: [ :each | each prepareMethodTransferBy: aSeamlessTransporter ]
+]

--- a/Seamless/CompiledMethod.extension.st
+++ b/Seamless/CompiledMethod.extension.st
@@ -4,9 +4,3 @@ Extension { #name : #CompiledMethod }
 CompiledMethod class >> definesWellKnownSeamlessClass [
 	^true
 ]
-
-{ #category : #'*Seamless' }
-CompiledMethod >> prepareValueTransferBy: aSeamlessTransporter [
-
-	self literalsDo: [ :each | each prepareMethodTransferBy: aSeamlessTransporter ]
-]

--- a/Seamless/LiteralVariable.extension.st
+++ b/Seamless/LiteralVariable.extension.st
@@ -4,3 +4,8 @@ Extension { #name : #LiteralVariable }
 LiteralVariable class >> definesWellKnownSeamlessClass [
 	^true
 ]
+
+{ #category : #'*Seamless' }
+LiteralVariable >> seamlessDefaultTransferStrategy [
+	^SeamlessTransferStrategy defaultByValue
+]

--- a/Seamless/Slot.extension.st
+++ b/Seamless/Slot.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #Slot }
+
+{ #category : #'*Seamless' }
+Slot >> seamlessDefaultTransferStrategy [
+	^SeamlessTransferStrategy defaultByValue
+]


### PR DESCRIPTION
Implement missing transfer logic for FullBlockClosure, CompiledBlock and Variables:
- In Pharo 9 variables were unified under Variable hierarchy and now they are used directly in AST. It requires explicit value transfer strategy for all of them. For compatibility with old images it is duplicated in LiteralVariable and Slot.
- FullBlockClosure support requires a Pharo fix https://github.com/pharo-project/pharo/pull/7321.  