### PR TITLE
Fixes to the pharo-ide/Seamless branch (dev13) for Pharo 13

### DIFF
--- a/BaselineOfSeamless/BaselineOfSeamless.class.st
+++ b/BaselineOfSeamless/BaselineOfSeamless.class.st
@@ -41,7 +41,7 @@ BaselineOfSeamless >> baseline: spec [
 			"------------"				
 			baseline: 'TostSerializer' with: [
 				spec
-					repository: 'github://pharo-ide/TostSerializer:v2.0.1';
+					repository: 'github://oliveiraallex/TostSerializer:dev13';
 					loads: 'Core'];
 			project: 'TostSerializerTests' copyFrom: 'TostSerializer' with: [
 				spec loads: 'Tests'];

--- a/BaselineOfSeamless/BaselineOfSeamless.class.st
+++ b/BaselineOfSeamless/BaselineOfSeamless.class.st
@@ -13,21 +13,21 @@ BaselineOfSeamless >> baseline: spec [
 		spec 
 			baseline: 'Basys' with: [
 				spec
-					repository: 'github://pharo-ide/Basys:v2.0.1';
+					repository: 'github://oliveiraallex/Basys:dev13';
 					loads: 'Core' ];
 			project: 'BasysTests' copyFrom: 'Basys' with: [
 				spec loads: 'Tests'];
 			"------------"				
 			baseline: 'ObjectStatistics' with: [
 				spec
-					repository: 'github://pharo-ide/ObjectStatistics:v2.0.1';
+					repository: 'github://oliveiraallex/ObjectStatistics:dev13';
 					loads: 'Core' ];
 			project: 'ObjectStatisticsTests' copyFrom: 'ObjectStatistics' with: [
 				spec loads: 'default' ];				
 			"------------"								
 			baseline: 'Ghost' with: [
 				spec
-					repository: 'github://pharo-ide/Ghost:v7.0.1';
+					repository: 'github://oliveiraallex/Ghost:dev13-1';
 					loads: 'ObjectGhost' ];
 			project: 'GhostTests' copyFrom: 'Ghost' with: [
 				spec loads: 'default'];
@@ -47,7 +47,7 @@ BaselineOfSeamless >> baseline: spec [
 				spec loads: 'Tests'];
 			"------------"						
 			baseline: 'Mocketry' with: [
-				spec repository: 'github://dionisiydk/Mocketry:v7.0.3' ].
+				spec repository: 'github://oliveiraallex/Mocketry:dev13' ].
 							
 		spec 
 			package: 'Seamless' with: [

--- a/BaselineOfSeamless/BaselineOfSeamless.class.st
+++ b/BaselineOfSeamless/BaselineOfSeamless.class.st
@@ -26,7 +26,7 @@ BaselineOfSeamless >> baseline: spec [
 			"------------"								
 			baseline: 'Ghost' with: [
 				spec
-					repository: 'github://pharo-ide/Ghost:v6.0.2';
+					repository: 'github://pharo-ide/Ghost:master';
 					loads: 'ObjectGhost' ];
 			project: 'GhostTests' copyFrom: 'Ghost' with: [
 				spec loads: 'default'];

--- a/BaselineOfSeamless/BaselineOfSeamless.class.st
+++ b/BaselineOfSeamless/BaselineOfSeamless.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #BaselineOfSeamless,
-	#superclass : #BaselineOf,
-	#category : #BaselineOfSeamless
+	#name : 'BaselineOfSeamless',
+	#superclass : 'BaselineOf',
+	#category : 'BaselineOfSeamless',
+	#package : 'BaselineOfSeamless'
 }
 
-{ #category : #baselines }
+{ #category : 'baselines' }
 BaselineOfSeamless >> baseline: spec [
 	<baseline>
 	spec for: #'common' do: [
@@ -26,7 +27,7 @@ BaselineOfSeamless >> baseline: spec [
 			"------------"								
 			baseline: 'Ghost' with: [
 				spec
-					repository: 'github://pharo-ide/Ghost:master';
+					repository: 'github://pharo-ide/Ghost:v7.0.1';
 					loads: 'ObjectGhost' ];
 			project: 'GhostTests' copyFrom: 'Ghost' with: [
 				spec loads: 'default'];
@@ -46,7 +47,7 @@ BaselineOfSeamless >> baseline: spec [
 				spec loads: 'Tests'];
 			"------------"						
 			baseline: 'Mocketry' with: [
-				spec repository: 'github://dionisiydk/Mocketry:v7.0.2' ].
+				spec repository: 'github://dionisiydk/Mocketry:v7.0.3' ].
 							
 		spec 
 			package: 'Seamless' with: [
@@ -62,13 +63,13 @@ BaselineOfSeamless >> baseline: spec [
 
 ]
 
-{ #category : #baselines }
+{ #category : 'baselines' }
 BaselineOfSeamless >> postLoad [
 
 	(self class environment classNamed: #SeamlessTransport) resetDefault
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 BaselineOfSeamless >> projectClass [
 	^ [ self class environment at: #MetacelloCypressBaselineProject ]
 		on: NotFound

--- a/BaselineOfSeamless/package.st
+++ b/BaselineOfSeamless/package.st
@@ -1,1 +1,1 @@
-Package { #name : #BaselineOfSeamless }
+Package { #name : 'BaselineOfSeamless' }

--- a/Seamless-NewToolsSupport/Object.extension.st
+++ b/Seamless-NewToolsSupport/Object.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Object }
+Extension { #name : 'Object' }
 
-{ #category : #'*Seamless-NewToolsSupport' }
+{ #category : '*Seamless-NewToolsSupport' }
 Object >> isRemoteDoItReceiver [
 	^false
 ]

--- a/Seamless-NewToolsSupport/SeamlessInspectorRemoteSlotNode.class.st
+++ b/Seamless-NewToolsSupport/SeamlessInspectorRemoteSlotNode.class.st
@@ -1,16 +1,17 @@
 Class {
-	#name : #SeamlessInspectorRemoteSlotNode,
-	#superclass : #StInspectorSlotNode,
-	#category : #'Seamless-NewToolsSupport'
+	#name : 'SeamlessInspectorRemoteSlotNode',
+	#superclass : 'StInspectorSlotNode',
+	#category : 'Seamless-NewToolsSupport',
+	#package : 'Seamless-NewToolsSupport'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessInspectorRemoteSlotNode >> rawValue [
 
 	^  self hostObject readRemoteSlot: self slot
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessInspectorRemoteSlotNode >> save: anObject [
 
 	self hostObject writeRemoteSlot: self slot 	value: anObject

--- a/Seamless-NewToolsSupport/SeamlessProxy.extension.st
+++ b/Seamless-NewToolsSupport/SeamlessProxy.extension.st
@@ -1,25 +1,25 @@
-Extension { #name : #SeamlessProxy }
+Extension { #name : 'SeamlessProxy' }
 
-{ #category : #'*Seamless-NewToolsSupport' }
+{ #category : '*Seamless-NewToolsSupport' }
 SeamlessProxy class >> compilerClass [
 
 	^SeamlessRemoteClassCompiler
 ]
 
-{ #category : #'*Seamless-NewToolsSupport' }
+{ #category : '*Seamless-NewToolsSupport' }
 SeamlessProxy >> inspect [
 	^ Smalltalk tools inspector inspect: self
 ]
 
-{ #category : #'*Seamless-NewToolsSupport' }
+{ #category : '*Seamless-NewToolsSupport' }
 SeamlessProxy >> isRemoteDoItReceiver [
 	^true
 ]
 
-{ #category : #'*Seamless-NewToolsSupport' }
-SeamlessProxy >> remoteInspection [
+{ #category : '*Seamless-NewToolsSupport' }
+SeamlessProxy >> remoteInspection: aBuilder [
 	"This is the most basic presentation showing the state of the object"
-	<inspectorPresentationOrder: 1000 title: 'Remote'>
 
-	^ SeamlessRemoteObjectInspection on: self
+	<inspectorPresentationOrder: 1000 title: 'Remote'>
+	^ aBuilder instantiate: SeamlessRemoteObjectInspection on: self
 ]

--- a/Seamless-NewToolsSupport/SeamlessRealCommunicationTests.extension.st
+++ b/Seamless-NewToolsSupport/SeamlessRealCommunicationTests.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #SeamlessRealCommunicationTests }
+Extension { #name : 'SeamlessRealCommunicationTests' }
 
-{ #category : #'*Seamless-NewToolsSupport' }
+{ #category : '*Seamless-NewToolsSupport' }
 SeamlessRealCommunicationTests >> testExecutingDoItWithGlobalReferenceOnRemoteObjectByRemoteCompiler [
  
 	| remoteEnv remotePoint compiler result localResult |
@@ -20,7 +20,7 @@ SeamlessRealCommunicationTests >> testExecutingDoItWithGlobalReferenceOnRemoteOb
 	localResult should equal: 1@3
 ]
 
-{ #category : #'*Seamless-NewToolsSupport' }
+{ #category : '*Seamless-NewToolsSupport' }
 SeamlessRealCommunicationTests >> testExecutingDoItWithInstVarAssignmentOnRemoteObject [
  
 	| remoteEnv remotePoint compiler result |
@@ -41,7 +41,7 @@ SeamlessRealCommunicationTests >> testExecutingDoItWithInstVarAssignmentOnRemote
 	result should equal: 4003
 ]
 
-{ #category : #'*Seamless-NewToolsSupport' }
+{ #category : '*Seamless-NewToolsSupport' }
 SeamlessRealCommunicationTests >> testExecutingDoItWithInstVarAssignmentOnRemoteObjectWhenRequestorIsSpecified [
  
 	| remoteEnv remotePoint compiler result requestor |

--- a/Seamless-NewToolsSupport/SeamlessRemoteClassCompiler.class.st
+++ b/Seamless-NewToolsSupport/SeamlessRemoteClassCompiler.class.st
@@ -1,10 +1,11 @@
 Class {
-	#name : #SeamlessRemoteClassCompiler,
-	#superclass : #OpalCompiler,
-	#category : #'Seamless-NewToolsSupport'
+	#name : 'SeamlessRemoteClassCompiler',
+	#superclass : 'OpalCompiler',
+	#category : 'Seamless-NewToolsSupport',
+	#package : 'Seamless-NewToolsSupport'
 }
 
-{ #category : #evaluation }
+{ #category : 'evaluation' }
 SeamlessRemoteClassCompiler >> evaluate [
 	"Compiles the sourceStream into a parse tree, then generates code into
 	 a method. If aContext is not nil, the text can refer to temporaries in that
@@ -13,26 +14,31 @@ SeamlessRemoteClassCompiler >> evaluate [
 	 compiled method is invoked from here via withArgs:executeMethod:, hence
 	 the system no longer creates Doit method litter on errors."
 
-	| value |
-	self noPattern: true.
-	self getSourceFromRequestorSelection.
-	
-	self class: (context 
-				ifNil: [ receiver remoteClass ]
-				ifNotNil: [ context compiledCode methodClass ]).
-	
+	| value doItContext |
+	self isScripting: true.
+	doItContext := self requestor doItContext.
+
+	self class: (doItContext
+			 ifNil: [ self receiver remoteClass ]
+			 ifNotNil: [ doItContext compiledCode methodClass ]).
+
 	compilationContext productionEnvironment: self class environment.
-	value := [ receiver withArgs: (context ifNil: [ #() ] ifNotNil: [ {context} ]) executeMethod: self compileDoit]
-		on: SyntaxErrorNotification 
-		do: [ :exception | 
-			self compilationContext requestor
-                ifNotNil: [
-						self compilationContext requestor 
-							notify: exception errorMessage , ' ->'
-							at: exception location
-							in: exception errorCode.
-                    self compilationContext failBlock value ]
-                ifNil: [ exception pass ]].
-	self logDoIt.
+	value := [
+		         self receiver
+			         withArgs:
+			         (doItContext ifNil: [ #(  ) ] ifNotNil: [ { doItContext } ])
+			         executeMethod: self compile ]
+		         on: OCSyntaxErrorNotice
+		         do: [ :exception |
+			         self requestor
+				         ifNotNil: [
+					         self requestor
+						         notify: exception errorMessage , ' ->'
+						         at: exception location
+						         in: exception errorCode.
+					         self failBlock value ]
+			         ifNil: [ exception pass ] ].
+	self logged == true ifTrue: [
+		self semanticScope announceDoItEvaluation: source by: self class codeSupportAnnouncer ].
 	^ value
 ]

--- a/Seamless-NewToolsSupport/SeamlessRemoteClassCompiler.class.st
+++ b/Seamless-NewToolsSupport/SeamlessRemoteClassCompiler.class.st
@@ -18,10 +18,6 @@ SeamlessRemoteClassCompiler >> evaluate [
 	self isScripting: true.
 	doItContext := self requestor doItContext.
 
-	self class: (doItContext
-			 ifNil: [ self receiver remoteClass ]
-			 ifNotNil: [ doItContext compiledCode methodClass ]).
-
 	compilationContext productionEnvironment: self class environment.
 	value := [
 		         self receiver

--- a/Seamless-NewToolsSupport/SeamlessRemoteObjectInspection.class.st
+++ b/Seamless-NewToolsSupport/SeamlessRemoteObjectInspection.class.st
@@ -1,16 +1,17 @@
 Class {
-	#name : #SeamlessRemoteObjectInspection,
-	#superclass : #GHGhostRawInspection,
-	#category : #'Seamless-NewToolsSupport'
+	#name : 'SeamlessRemoteObjectInspection',
+	#superclass : 'GHGhostRawInspection',
+	#category : 'Seamless-NewToolsSupport',
+	#package : 'Seamless-NewToolsSupport'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRemoteObjectInspection >> inspectorNodes [
 
 	^self inspectorNodesFor: self model
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRemoteObjectInspection >> inspectorNodesFor: anObject [ 
 
 	| allSlots nodes |
@@ -21,7 +22,7 @@ SeamlessRemoteObjectInspection >> inspectorNodesFor: anObject [
 	^{ StInspectorSelfNode hostObject: anObject }, nodes
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRemoteObjectInspection >> setAttributeTable [
 
 	attributeTable

--- a/Seamless-NewToolsSupport/SeamlessRemoteScriptResult.class.st
+++ b/Seamless-NewToolsSupport/SeamlessRemoteScriptResult.class.st
@@ -1,29 +1,30 @@
 Class {
-	#name : #SeamlessRemoteScriptResult,
-	#superclass : #Object,
+	#name : 'SeamlessRemoteScriptResult',
+	#superclass : 'Object',
 	#instVars : [
 		'value'
 	],
-	#category : #'Seamless-NewToolsSupport'
+	#category : 'Seamless-NewToolsSupport',
+	#package : 'Seamless-NewToolsSupport'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessRemoteScriptResult class >> value: anObjectOrProxy [
 	^self new 
 		value: anObjectOrProxy
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SeamlessRemoteScriptResult >> printString [
 	^value remotePrintString 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRemoteScriptResult >> value [
 	^ value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRemoteScriptResult >> value: anObject [
 	value := anObject
 ]

--- a/Seamless-NewToolsSupport/SeamlessRemoteWorkspaceVariable.class.st
+++ b/Seamless-NewToolsSupport/SeamlessRemoteWorkspaceVariable.class.st
@@ -14,22 +14,23 @@ Internal Representation and Key Implementation Points.
 	state:		<SeamlessLocalVariableState>
 "
 Class {
-	#name : #SeamlessRemoteWorkspaceVariable,
-	#superclass : #WorkspaceVariable,
+	#name : 'SeamlessRemoteWorkspaceVariable',
+	#superclass : 'WorkspaceVariable',
 	#instVars : [
 		'state'
 	],
-	#category : #'Seamless-NewToolsSupport'
+	#category : 'Seamless-NewToolsSupport',
+	#package : 'Seamless-NewToolsSupport'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessRemoteWorkspaceVariable class >> key: aKey [ 
 
 	^self new
 		 key: aKey
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 SeamlessRemoteWorkspaceVariable >> emitStore: methodBuilder [
 
 	| tempName |
@@ -43,7 +44,7 @@ SeamlessRemoteWorkspaceVariable >> emitStore: methodBuilder [
 		send: #write:
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 SeamlessRemoteWorkspaceVariable >> emitValue: methodBuilder [
 
 	methodBuilder 
@@ -51,24 +52,24 @@ SeamlessRemoteWorkspaceVariable >> emitValue: methodBuilder [
 		send: #read
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 SeamlessRemoteWorkspaceVariable >> initialize [
 	super initialize.
 	
 	state := SeamlessLocalVariableState of: self
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessRemoteWorkspaceVariable >> isOnlyDefaultTransferStrategyAllowed [
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRemoteWorkspaceVariable >> seamlessDefaultTransferStrategy [
 	^SeamlessTransferStrategy defaultByReference 
 ]
 
-{ #category : #'code generation' }
+{ #category : 'code generation' }
 SeamlessRemoteWorkspaceVariable >> write: anObject [
 	super write: anObject.
 	state value: anObject.

--- a/Seamless-NewToolsSupport/package.st
+++ b/Seamless-NewToolsSupport/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Seamless-NewToolsSupport' }
+Package { #name : 'Seamless-NewToolsSupport' }

--- a/Seamless/Array.extension.st
+++ b/Seamless/Array.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Array }
+Extension { #name : 'Array' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Array >> prepareMethodTransferBy: aSeamlessTransporter [
 	super prepareMethodTransferBy: aSeamlessTransporter.
 	

--- a/Seamless/Association.extension.st
+++ b/Seamless/Association.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Association }
+Extension { #name : 'Association' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Association class >> definesWellKnownSeamlessClass [
 	^true
 ]

--- a/Seamless/BasysConnection.extension.st
+++ b/Seamless/BasysConnection.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #BasysConnection }
+Extension { #name : 'BasysConnection' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 BasysConnection >> createIdentificationContext [ 
 	^SeamlessPeerIdentificationContext for: self
 ]

--- a/Seamless/Bitmap.extension.st
+++ b/Seamless/Bitmap.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Bitmap }
+Extension { #name : 'Bitmap' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Bitmap >> seamlessDefaultTransferStrategy [
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/BlockCannotReturn.extension.st
+++ b/Seamless/BlockCannotReturn.extension.st
@@ -1,11 +1,11 @@
-Extension { #name : #BlockCannotReturn }
+Extension { #name : 'BlockCannotReturn' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 BlockCannotReturn class >> definesWellKnownSeamlessClass [
 	^true
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 BlockCannotReturn >> handleSeamlessRequest: anEvaluationRequest receivedFrom: senderPeer [
 	| seamlessResult |
 	seamlessResult := SeamlessNonLocalReturnResult with: result homeContext: home.

--- a/Seamless/BlockClosure.extension.st
+++ b/Seamless/BlockClosure.extension.st
@@ -8,24 +8,28 @@ BlockClosure class >> definesWellKnownSeamlessClass [
 { #category : '*Seamless' }
 BlockClosure >> prepareValueTransferBy: aSeamlessTransporter [
 	"For me transfer by values means that I could be evaluated directly on remote side"
+
 	| mostOuterContext |
-	
 	mostOuterContext := self outerContext.
-	[mostOuterContext closure notNil ] whileTrue: [ 
-		aSeamlessTransporter transferByValue: mostOuterContext. 
-		aSeamlessTransporter transferByValue: mostOuterContext closure.
-		aSeamlessTransporter transferByValue: mostOuterContext method.
-		mostOuterContext := mostOuterContext outerContext].
- 
-	mostOuterContext == self home ifFalse: [ self error: [ 'It should not happen' ] ].
-	
-	self hasMethodReturn 
-		ifTrue: [ 
-			aSeamlessTransporter transfer: mostOuterContext byReference: [ 
-				SeamlessObjectCopyReference to: mostOuterContext ]] 
+	[ mostOuterContext notNil and: [ mostOuterContext closure notNil ] ]
+		whileTrue: [
+				aSeamlessTransporter transferByValue: mostOuterContext.
+				aSeamlessTransporter transferByValue: mostOuterContext closure.
+				aSeamlessTransporter transferByValue: mostOuterContext method.
+				mostOuterContext := mostOuterContext outerContext ].
+
+	mostOuterContext == self home ifFalse: [
+		self error: [ 'It should not happen' ] ].
+
+	self method hasMethodReturn
+		ifTrue: [
+				aSeamlessTransporter
+					transfer: mostOuterContext
+					byReference: [ SeamlessObjectCopyReference to: mostOuterContext ] ]
 		ifFalse: [ aSeamlessTransporter transferByValue: mostOuterContext ].
 
-	aSeamlessTransporter transferByValue: mostOuterContext method.
+	mostOuterContext ifNotNil: [
+		aSeamlessTransporter transferByValue: mostOuterContext method ]
 	"following commented line is required to evaluate blocks which are referenced inst vars of home receiver"
 	"anObjectTransporter transferAsValue: mostOuterContext receiver"
 ]

--- a/Seamless/BlockClosure.extension.st
+++ b/Seamless/BlockClosure.extension.st
@@ -1,11 +1,11 @@
-Extension { #name : #BlockClosure }
+Extension { #name : 'BlockClosure' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 BlockClosure class >> definesWellKnownSeamlessClass [
 	^true
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 BlockClosure >> prepareValueTransferBy: aSeamlessTransporter [
 	"For me transfer by values means that I could be evaluated directly on remote side"
 	| mostOuterContext |

--- a/Seamless/Boolean.extension.st
+++ b/Seamless/Boolean.extension.st
@@ -1,11 +1,11 @@
-Extension { #name : #Boolean }
+Extension { #name : 'Boolean' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Boolean >> isOnlyDefaultTransferStrategyAllowed [
 	^true
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Boolean >> seamlessDefaultTransferStrategy [
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/ByteArray.extension.st
+++ b/Seamless/ByteArray.extension.st
@@ -1,13 +1,24 @@
-Extension { #name : #ByteArray }
+Extension { #name : 'ByteArray' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 ByteArray class >> definesWellKnownSeamlessClass [ 
 	^true
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 ByteArray >> prepareMethodTransferBy: aSeamlessTransporter [
 	super prepareMethodTransferBy: aSeamlessTransporter.
 	
 	aSeamlessTransporter transferByValue: self
+]
+
+{ #category : '*Seamless' }
+ByteArray >> seamlessDefaultTransferStrategy [ 
+	"Raw binary data should always be transferred as a real copy, never as
+	 a remote reference/proxy. This was previously unspecified and fell
+	 back to Object's default (by reference), which silently turned any
+	 ByteArray-valued instance variable of a by-value object (e.g. UUID's
+	 #uuidData on Pharo 14+) into a proxy — causing unexpected extra
+	 round-trips and, in the peer identification handshake, a deadlock."
+	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/Character.extension.st
+++ b/Seamless/Character.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Character }
+Extension { #name : 'Character' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Character >> seamlessDefaultTransferStrategy [
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/ClassDescription.extension.st
+++ b/Seamless/ClassDescription.extension.st
@@ -1,20 +1,20 @@
-Extension { #name : #ClassDescription }
+Extension { #name : 'ClassDescription' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 ClassDescription >> definesWellKnownSeamlessClass [
 	"look at #isWellKnownSeamlessClass"
 	
 	^false
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 ClassDescription >> definesWellKnownSeamlessClassHierarchy [
 	"look at #isWellKnownSeamlessClass"
 	
 	^false
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 ClassDescription >> isWellKnownSeamlessClass [
 	"Classes which define method #definesWellKnownSeamlessClass as true will be collected as well known classes for seamless transfer. Well known classes is optimization for seamless communication protocol to reduce size of transferred packets.
 	If class only inherits method #definesWellKnownSeamlessClass (from superclasses) then it will not be well known. To force full hierarchy of classes be well known method #isWellKnownSeamlessClassHierarchy should be implemented with true by superclass"

--- a/Seamless/ClassVariable.extension.st
+++ b/Seamless/ClassVariable.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #ClassVariable }
+Extension { #name : 'ClassVariable' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 ClassVariable class >> definesWellKnownSeamlessClass [
 	^true
 ]

--- a/Seamless/Collection.extension.st
+++ b/Seamless/Collection.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Collection }
+Extension { #name : 'Collection' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Collection class >> definesWellKnownSeamlessClass [ 
 	^{Set package. OrderedCollection package} includes: self package
 ]

--- a/Seamless/Color.extension.st
+++ b/Seamless/Color.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Color }
+Extension { #name : 'Color' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Color >> seamlessDefaultTransferStrategy [
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/CompiledBlock.extension.st
+++ b/Seamless/CompiledBlock.extension.st
@@ -1,13 +1,13 @@
-Extension { #name : #CompiledBlock }
+Extension { #name : 'CompiledBlock' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 CompiledBlock >> isOnlyDefaultTransferStrategyAllowed [
 	"CompiledBlock is an essential part of CompiledMethod with strong requirements from the VM.
 	So it must be always transferred by value"	
 	^true
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 CompiledBlock >> seamlessDefaultTransferStrategy [
 	"CompiledBlock is an essential part of CompiledMethod with strong requirements from the VM.
 	So it must be always transferred by value"

--- a/Seamless/CompiledCode.extension.st
+++ b/Seamless/CompiledCode.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #CompiledCode }
+Extension { #name : 'CompiledCode' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 CompiledCode >> prepareValueTransferBy: aSeamlessTransporter [
 
 	self literalsDo: [ :each | each prepareMethodTransferBy: aSeamlessTransporter ]

--- a/Seamless/CompiledMethod.extension.st
+++ b/Seamless/CompiledMethod.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #CompiledMethod }
+Extension { #name : 'CompiledMethod' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 CompiledMethod class >> definesWellKnownSeamlessClass [
 	^true
 ]

--- a/Seamless/Context.extension.st
+++ b/Seamless/Context.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Context }
+Extension { #name : 'Context' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Context class >> definesWellKnownSeamlessClass [ 
 	^true
 ]

--- a/Seamless/DateAndTime.extension.st
+++ b/Seamless/DateAndTime.extension.st
@@ -1,11 +1,11 @@
-Extension { #name : #DateAndTime }
+Extension { #name : 'DateAndTime' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 DateAndTime class >> definesWellKnownSeamlessClass [
 	^true
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 DateAndTime >> seamlessDefaultTransferStrategy [
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/Duration.extension.st
+++ b/Seamless/Duration.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Duration }
+Extension { #name : 'Duration' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Duration >> seamlessDefaultTransferStrategy [
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/Exception.extension.st
+++ b/Seamless/Exception.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Exception }
+Extension { #name : 'Exception' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Exception >> handleSeamlessRequest: anEvaluationRequest receivedFrom: senderPeer [
 
 	| remoteError result |

--- a/Seamless/Form.extension.st
+++ b/Seamless/Form.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Form }
+Extension { #name : 'Form' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Form >> seamlessDefaultTransferStrategy [
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/GlobalVariable.extension.st
+++ b/Seamless/GlobalVariable.extension.st
@@ -1,11 +1,11 @@
-Extension { #name : #GlobalVariable }
+Extension { #name : 'GlobalVariable' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 GlobalVariable class >> definesWellKnownSeamlessClass [
 	^true
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 GlobalVariable >> prepareMethodTransferBy: aSeamlessTransporter [
 	super prepareMethodTransferBy: aSeamlessTransporter.
 	

--- a/Seamless/Halt.extension.st
+++ b/Seamless/Halt.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Halt }
+Extension { #name : 'Halt' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Halt >> handleSeamlessRequest: anEvaluationRequest receivedFrom: senderPeer [
 	self pass
 ]

--- a/Seamless/HashedCollection.extension.st
+++ b/Seamless/HashedCollection.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #HashedCollection }
+Extension { #name : 'HashedCollection' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 HashedCollection >> prepareValueTransferBy: aSeamlessTransporter [
 
 	aSeamlessTransporter transferByValue: array	

--- a/Seamless/LiteralVariable.extension.st
+++ b/Seamless/LiteralVariable.extension.st
@@ -1,11 +1,11 @@
-Extension { #name : #LiteralVariable }
+Extension { #name : 'LiteralVariable' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 LiteralVariable class >> definesWellKnownSeamlessClass [
 	^true
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 LiteralVariable >> seamlessDefaultTransferStrategy [
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/LookupKey.extension.st
+++ b/Seamless/LookupKey.extension.st
@@ -1,11 +1,11 @@
-Extension { #name : #LookupKey }
+Extension { #name : 'LookupKey' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 LookupKey class >> definesWellKnownSeamlessClass [
 	^true
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 LookupKey >> seamlessDefaultTransferStrategy [
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/MessageSend.extension.st
+++ b/Seamless/MessageSend.extension.st
@@ -1,17 +1,17 @@
-Extension { #name : #MessageSend }
+Extension { #name : 'MessageSend' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 MessageSend class >> definesWellKnownSeamlessClass [ 
 	^true
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 MessageSend >> prepareValueTransferBy: aSeamlessTransporter [
 
 	aSeamlessTransporter transferByValue: arguments
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 MessageSend >> seamlessDefaultTransferStrategy [ 
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/Metaclass.extension.st
+++ b/Seamless/Metaclass.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Metaclass }
+Extension { #name : 'Metaclass' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Metaclass class >> definesWellKnownSeamlessClass [ 
 	^true
 ]

--- a/Seamless/Notification.extension.st
+++ b/Seamless/Notification.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Notification }
+Extension { #name : 'Notification' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Notification >> handleSeamlessRequest: anEvaluationRequest receivedFrom: senderPeer [
 	self pass
 ]

--- a/Seamless/Number.extension.st
+++ b/Seamless/Number.extension.st
@@ -1,16 +1,16 @@
-Extension { #name : #Number }
+Extension { #name : 'Number' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Number class >> definesWellKnownSeamlessClass [ 
 	^self package = Number package
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Number class >> definesWellKnownSeamlessClassHierarchy [ 
 	^true
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Number >> seamlessDefaultTransferStrategy [
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/Object.extension.st
+++ b/Seamless/Object.extension.st
@@ -1,60 +1,60 @@
-Extension { #name : #Object }
+Extension { #name : 'Object' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Object >> asLocalDeepCopy [
 	^self
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Object >> asLocalObject [
 	^self
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Object >> asTransferredByDeepCopy [
 	^SeamlessDeepCopyContainer with: self
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Object >> asTransferredByValue [
 	^SeamlessObjectValueContainer with: self
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Object >> createSeamlessReference [
 	^SeamlessObjectReference new
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Object >> isOnlyDefaultTransferStrategyAllowed [
 	^false
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Object >> isSeamlessProxy [
 	^false
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Object >> nameForSeamlessStatistics [
 
 	^self class name
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Object >> prepareLocalSubstitutionIn: aSeamlessNetwork with: aSeamlessTransporter [
 
 	aSeamlessTransporter atNextStepProcess: self
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Object >> prepareMethodTransferBy: aSeamlessTransporter [
 	"This method is called for each method literal when method is going to be transferred by value.
 	GlobalVariable in that case (like class reference) can override this method 
 	to manage the transporter to transfer the class as well known object"
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Object >> prepareValueForTransferBy: aSeamlessTransporter [
 	"Any object can define value object which will be transferred over network.
 	By default it is object itself. 
@@ -65,7 +65,7 @@ Object >> prepareValueForTransferBy: aSeamlessTransporter [
 	^self
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Object >> prepareValueTransferBy: aSeamlessTransporter [
 	"By default transporter will send shallow copy of object to remote side.
 	And all internal state will be transferred by their own transfer strategies.
@@ -78,7 +78,7 @@ Object >> prepareValueTransferBy: aSeamlessTransporter [
 	Look for example at OrderedCollection"
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Object >> printForSeamlessLog [
 	^String streamContents: [ :s | 
 		s 
@@ -89,22 +89,22 @@ Object >> printForSeamlessLog [
 	]
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Object >> remoteClass [
 	^self class
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Object >> remotePrintString [
 	^self printString
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Object >> seamlessDefaultTransferStrategy [
 	^SeamlessTransferStrategy defaultByReference 
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Object >> seamlessIsBindingVisible: aString [
 	"this methods is suitable for tools to detect if some binding visible by remote object.
 	For example inspector evaluators could use it to distinguish local workspace variable 

--- a/Seamless/OrderedCollection.extension.st
+++ b/Seamless/OrderedCollection.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #OrderedCollection }
+Extension { #name : 'OrderedCollection' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 OrderedCollection >> prepareValueTransferBy: aSeamlessTransporter [
 
 	aSeamlessTransporter transferByValue: array	

--- a/Seamless/PrimitiveFailed.extension.st
+++ b/Seamless/PrimitiveFailed.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #PrimitiveFailed }
+Extension { #name : 'PrimitiveFailed' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 PrimitiveFailed >> handleSeamlessRequest: anEvaluationRequest receivedFrom: senderPeer [
 
 	anEvaluationRequest processPrimitiveFailure: self

--- a/Seamless/RunArray.extension.st
+++ b/Seamless/RunArray.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #RunArray }
+Extension { #name : 'RunArray' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 RunArray >> prepareValueTransferBy: aSeamlessTransporter [
 	
 	aSeamlessTransporter transferByValue: runs.

--- a/Seamless/SeamlessBlockEvaluationRequest.class.st
+++ b/Seamless/SeamlessBlockEvaluationRequest.class.st
@@ -2,28 +2,30 @@
 I am request to execute block on remote side (my valuable instance is one args block closure)
 "
 Class {
-	#name : #SeamlessBlockEvaluationRequest,
-	#superclass : #SeamlessEvaluationRequest,
-	#category : #'Seamless-Requests'
+	#name : 'SeamlessBlockEvaluationRequest',
+	#superclass : 'SeamlessEvaluationRequest',
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessBlockEvaluationRequest >> block [
 	^ valuable
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SeamlessBlockEvaluationRequest >> printBlock [
 	^self block sourceNode formattedCode
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SeamlessBlockEvaluationRequest >> printMessageForLog [
 	"Do not use #printBlock as it could lead to many message sends back to remote side"
 	^'Remote block request' 
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SeamlessBlockEvaluationRequest >> printOn: aStream [
 
 	super printOn: aStream.

--- a/Seamless/SeamlessClosePeerRequest.class.st
+++ b/Seamless/SeamlessClosePeerRequest.class.st
@@ -2,12 +2,14 @@
 I am request to notify remote side that sender peer was destroyed. So remote side could cleanup anything related to sender like distributed objects, remote peer instance and established connections.
 "
 Class {
-	#name : #SeamlessClosePeerRequest,
-	#superclass : #SeamlessRequest,
-	#category : #'Seamless-Requests'
+	#name : 'SeamlessClosePeerRequest',
+	#superclass : 'SeamlessRequest',
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #execution }
+{ #category : 'execution' }
 SeamlessClosePeerRequest >> executeFor: senderPeer [
 	
 	senderPeer closeByRemoteSide

--- a/Seamless/SeamlessDeepCopyContainer.class.st
+++ b/Seamless/SeamlessDeepCopyContainer.class.st
@@ -5,12 +5,14 @@ I command transporter to transfer my content by deep copy
 
 "
 Class {
-	#name : #SeamlessDeepCopyContainer,
-	#superclass : #SeamlessObjectValueContainer,
-	#category : 'Seamless-Core'
+	#name : 'SeamlessDeepCopyContainer',
+	#superclass : 'SeamlessObjectValueContainer',
+	#category : 'Seamless-Core',
+	#package : 'Seamless',
+	#tag : 'Core'
 }
 
-{ #category : #transfer }
+{ #category : 'transfer' }
 SeamlessDeepCopyContainer >> prepareValueTransferBy: aSeamlessTransporter [
 
 	aSeamlessTransporter transferByDeepCopy: content

--- a/Seamless/SeamlessDefaultRequestContext.class.st
+++ b/Seamless/SeamlessDefaultRequestContext.class.st
@@ -12,16 +12,18 @@ To stop this communication ""return request"" is sent with default context (whic
 This approach allows reuse SeamlessMessageSendRequest to implement request return. Instead some kind of ReturnMessageResultRequest will be needed
 "
 Class {
-	#name : #SeamlessDefaultRequestContext,
-	#superclass : #SeamlessRequestContext,
-	#category : 'Seamless-Requests'
+	#name : 'SeamlessDefaultRequestContext',
+	#superclass : 'SeamlessRequestContext',
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessDefaultRequestContext >> return: aSeamlessRequestResult to: senderPeer [
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessDefaultRequestContext >> seamlessDefaultTransferStrategy [ 
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/SeamlessDefaultTransferStrategy.class.st
+++ b/Seamless/SeamlessDefaultTransferStrategy.class.st
@@ -5,12 +5,14 @@ In that case this such subset of objects we could apply me as strategy.
 
 "
 Class {
-	#name : #SeamlessDefaultTransferStrategy,
-	#superclass : #SeamlessTransferStrategy,
-	#category : 'Seamless-Transport'
+	#name : 'SeamlessDefaultTransferStrategy',
+	#superclass : 'SeamlessTransferStrategy',
+	#category : 'Seamless-Transport',
+	#package : 'Seamless',
+	#tag : 'Transport'
 }
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessDefaultTransferStrategy >> prepareTransferObjectFor: anObject by: anObjectTransporter [
 	
 	^anObject seamlessDefaultTransferStrategy 

--- a/Seamless/SeamlessDeliverResultRequest.class.st
+++ b/Seamless/SeamlessDeliverResultRequest.class.st
@@ -11,39 +11,41 @@ Internal Representation and Key Implementation Points.
 	result:		<SeamlessRequestResult>
 "
 Class {
-	#name : #SeamlessDeliverResultRequest,
-	#superclass : #SeamlessRequest,
+	#name : 'SeamlessDeliverResultRequest',
+	#superclass : 'SeamlessRequest',
 	#instVars : [
 		'result'
 	],
-	#category : 'Seamless-Requests'
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessDeliverResultRequest class >> result: aSeamlessRequestResult to: aSeamlessRemoteContext [
 	^self new 
 		context: aSeamlessRemoteContext;
 		result: aSeamlessRequestResult 
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SeamlessDeliverResultRequest >> executeFor: senderPeer [
 	
 	context return: result
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessDeliverResultRequest >> ownBytes: aNumber [
 
 	result transferredBytes: aNumber
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessDeliverResultRequest >> result [
 	^ result
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessDeliverResultRequest >> result: anObject [
 	result := anObject
 ]

--- a/Seamless/SeamlessDistributedObjects.class.st
+++ b/Seamless/SeamlessDistributedObjects.class.st
@@ -21,8 +21,8 @@ returnes reference for given object. If not found I create it and bound it to gi
 	referencesToObjects:		<Dictionary>
 "
 Class {
-	#name : #SeamlessDistributedObjects,
-	#superclass : #Object,
+	#name : 'SeamlessDistributedObjects',
+	#superclass : 'Object',
 	#instVars : [
 		'network',
 		'lock',
@@ -30,17 +30,19 @@ Class {
 		'referencesToObjects',
 		'lastReferenceId'
 	],
-	#category : #'Seamless-Core'
+	#category : 'Seamless-Core',
+	#package : 'Seamless',
+	#tag : 'Core'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessDistributedObjects class >> over: aSeamlessNetwork [
 
 	^self new 
 		network: aSeamlessNetwork 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessDistributedObjects >> at: aSeamlessObjectReference ifAbsentUseProxy: proxyBlock [
 	| object |
 	object := lock criticalRead: [ referencesToObjects at: aSeamlessObjectReference ifAbsent: [ nil ] ].
@@ -57,7 +59,7 @@ SeamlessDistributedObjects >> at: aSeamlessObjectReference ifAbsentUseProxy: pro
 	^object
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessDistributedObjects >> at: aSeamlessObjectReference ifPresent: presentBlock ifAbsentUseProxy: proxyBlock [
 	| object |
 	object := lock criticalRead: [ referencesToObjects at: aSeamlessObjectReference ifAbsent: [ nil ] ].
@@ -76,14 +78,14 @@ SeamlessDistributedObjects >> at: aSeamlessObjectReference ifPresent: presentBlo
 	^object
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessDistributedObjects >> clear [
 	lock criticalWrite: [ 
 		objectsToReferences removeAll.
 		referencesToObjects removeAll]
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SeamlessDistributedObjects >> createNewReferenceFor: anObject by: refCreationBlock [
 	"it should be called inside lock critical section"
 	
@@ -102,12 +104,12 @@ SeamlessDistributedObjects >> createNewReferenceFor: anObject by: refCreationBlo
 	^reference
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessDistributedObjects >> includesReference: aSeamlessObjectReference [ 
 	^lock criticalRead: [ referencesToObjects includesKey: aSeamlessObjectReference]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SeamlessDistributedObjects >> initialize [
 	super initialize.
 	
@@ -117,12 +119,12 @@ SeamlessDistributedObjects >> initialize [
 	referencesToObjects := Dictionary new.
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessDistributedObjects >> isEmpty [
 	^referencesToObjects isEmpty
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessDistributedObjects >> localForReferenceId: id [ 
 	| reference |
 	reference := objectsToReferences keysAndValuesDo: [ :o :ref | 
@@ -132,27 +134,27 @@ SeamlessDistributedObjects >> localForReferenceId: id [
 	KeyNotFound signalFor: id in: self 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessDistributedObjects >> network [
 	^ network
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessDistributedObjects >> network: anObject [
 	network := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessDistributedObjects >> objectsToReferences [
 	^ objectsToReferences
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessDistributedObjects >> objectsToReferences: anObject [
 	objectsToReferences := anObject
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SeamlessDistributedObjects >> printOn: aStream [
 	super printOn: aStream.
 
@@ -162,7 +164,7 @@ SeamlessDistributedObjects >> printOn: aStream [
 		nextPutAll: ')'
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessDistributedObjects >> referenceFor: anObject ifNewUse: refCreationBlock [
 	| reference |
 	(anObject isSeamlessProxy and: [ anObject seamlessReference ownerPeerId = network localPeerId])
@@ -180,17 +182,17 @@ SeamlessDistributedObjects >> referenceFor: anObject ifNewUse: refCreationBlock 
 	^reference
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessDistributedObjects >> referencesToObjects [
 	^ referencesToObjects
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessDistributedObjects >> referencesToObjects: anObject [
 	referencesToObjects := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessDistributedObjects >> remove: anObject [ 
 	| reference |
 	lock criticalWrite: [ 
@@ -198,7 +200,7 @@ SeamlessDistributedObjects >> remove: anObject [
 		referencesToObjects removeKey: reference]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessDistributedObjects >> removeAt: aSeamlessObjectReference [ 
 	| object |
 	lock criticalWrite: [
@@ -206,7 +208,7 @@ SeamlessDistributedObjects >> removeAt: aSeamlessObjectReference [
 		objectsToReferences removeKey: object]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessDistributedObjects >> removeObjectsDistributedBy: aRemotePeer [
 	
 	| references |
@@ -220,7 +222,7 @@ SeamlessDistributedObjects >> removeObjectsDistributedBy: aRemotePeer [
 	]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessDistributedObjects >> size [
 	^referencesToObjects size
 ]

--- a/Seamless/SeamlessEvaluationRequest.class.st
+++ b/Seamless/SeamlessEvaluationRequest.class.st
@@ -12,21 +12,23 @@ Look it comments.
 	evaluable:		<MessageSend or: BlockClosure>
 "
 Class {
-	#name : #SeamlessEvaluationRequest,
-	#superclass : #SeamlessRequest,
+	#name : 'SeamlessEvaluationRequest',
+	#superclass : 'SeamlessRequest',
 	#instVars : [
 		'valuable'
 	],
-	#category : 'Seamless-Requests'
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessEvaluationRequest class >> with: aBlockOrMessageSend [
 	^self new 
 		valuable: aBlockOrMessageSend
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SeamlessEvaluationRequest >> executeFor: senderPeer [
 	| result |	 
 	[
@@ -38,13 +40,13 @@ SeamlessEvaluationRequest >> executeFor: senderPeer [
 		err handleSeamlessRequest: self receivedFrom: senderPeer ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessEvaluationRequest >> prepareValueTransferBy: aSeamlessTransporter [
 
 	aSeamlessTransporter transferByValue: valuable
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SeamlessEvaluationRequest >> processMethodExecutePrimitiveFailure: aPrimitiveFailed [
 
 	| args failedContext primitiveArguments result method |
@@ -66,7 +68,7 @@ SeamlessEvaluationRequest >> processMethodExecutePrimitiveFailure: aPrimitiveFai
 	failedContext return: result
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SeamlessEvaluationRequest >> processPerformPrimitiveFailure: aPrimitiveFailed [
 
 	| args failedContext primitiveArguments result |
@@ -86,7 +88,7 @@ SeamlessEvaluationRequest >> processPerformPrimitiveFailure: aPrimitiveFailed [
 	failedContext return: result
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SeamlessEvaluationRequest >> processPrimitiveFailure: aPrimitiveFailed [
 
 	aPrimitiveFailed selector == #perform:withArguments:inSuperclass: 
@@ -98,7 +100,7 @@ SeamlessEvaluationRequest >> processPrimitiveFailure: aPrimitiveFailed [
 	aPrimitiveFailed pass 
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SeamlessEvaluationRequest >> returnResult: aSeamlessRequestResult to: senderPeer [
 
 	context return: aSeamlessRequestResult to: senderPeer.
@@ -106,12 +108,12 @@ SeamlessEvaluationRequest >> returnResult: aSeamlessRequestResult to: senderPeer
 	resultBytes := aSeamlessRequestResult transferredBytes
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessEvaluationRequest >> valuable [
 	^valuable
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessEvaluationRequest >> valuable: anObject [
 	valuable := anObject
 ]

--- a/Seamless/SeamlessGetEnvironmentRequest.class.st
+++ b/Seamless/SeamlessGetEnvironmentRequest.class.st
@@ -2,12 +2,14 @@
 I return remote Smalltalk instance to sender
 "
 Class {
-	#name : #SeamlessGetEnvironmentRequest,
-	#superclass : #SeamlessRequest,
-	#category : 'Seamless-Requests'
+	#name : 'SeamlessGetEnvironmentRequest',
+	#superclass : 'SeamlessRequest',
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #execution }
+{ #category : 'execution' }
 SeamlessGetEnvironmentRequest >> executeFor: senderPeer [
 
 	context returnValue: Smalltalk to: senderPeer

--- a/Seamless/SeamlessLearningProxy.class.st
+++ b/Seamless/SeamlessLearningProxy.class.st
@@ -9,20 +9,22 @@ Internal Representation and Key Implementation Points.
 	learning:		<GHLearning>
 "
 Class {
-	#name : #SeamlessLearningProxy,
-	#superclass : #SeamlessProxy,
+	#name : 'SeamlessLearningProxy',
+	#superclass : 'SeamlessProxy',
 	#instVars : [
 		'learning'
 	],
-	#category : 'Seamless-Proxy'
+	#category : 'Seamless-Proxy',
+	#package : 'Seamless',
+	#tag : 'Proxy'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SeamlessLearningProxy >> ghostBehaviour [
 	^learning
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SeamlessLearningProxy >> seamlessReference: aSeamlessObjectReference [
 	super seamlessReference: aSeamlessObjectReference.
 	

--- a/Seamless/SeamlessLoadDeepCopyRequest.class.st
+++ b/Seamless/SeamlessLoadDeepCopyRequest.class.st
@@ -3,12 +3,14 @@ I am special kind of loading remote object request.
 I force deep copy loading strategy which will transfer full object graph by value to sender
 "
 Class {
-	#name : #SeamlessLoadDeepCopyRequest,
-	#superclass : #SeamlessLoadObjectRequest,
-	#category : 'Seamless-Requests'
+	#name : 'SeamlessLoadDeepCopyRequest',
+	#superclass : 'SeamlessLoadObjectRequest',
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #execution }
+{ #category : 'execution' }
 SeamlessLoadDeepCopyRequest >> executeFor: senderPeer [
 "On sender peer my objectProxy is SeamlessProxy which points to requested remote object.
 But on receiver peer my objectProxy will contain real distributed object. 

--- a/Seamless/SeamlessLoadObjectRequest.class.st
+++ b/Seamless/SeamlessLoadObjectRequest.class.st
@@ -16,21 +16,23 @@ Internal Representation and Key Implementation Points.
 	objectProxy:		<SeamlessProxy>
 "
 Class {
-	#name : #SeamlessLoadObjectRequest,
-	#superclass : #SeamlessRequest,
+	#name : 'SeamlessLoadObjectRequest',
+	#superclass : 'SeamlessRequest',
 	#instVars : [
 		'objectProxy'
 	],
-	#category : 'Seamless-Requests'
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessLoadObjectRequest class >> proxy: aSeamlessProxy [
 	^self new 
 		objectProxy: aSeamlessProxy
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SeamlessLoadObjectRequest >> executeFor: senderPeer [
 	"On sender peer my objectProxy is SeamlessProxy which points to requested remote object.
 	But on receiver peer my objectProxy will contain real distributed object. 
@@ -41,12 +43,12 @@ SeamlessLoadObjectRequest >> executeFor: senderPeer [
 	context returnValue: referenceOrLoadedRemoteObject asTransferredByValue to: senderPeer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessLoadObjectRequest >> objectProxy [
 	^ objectProxy
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessLoadObjectRequest >> objectProxy: anObject [
 	objectProxy := anObject
 ]

--- a/Seamless/SeamlessLocalVariableState.class.st
+++ b/Seamless/SeamlessLocalVariableState.class.st
@@ -13,23 +13,25 @@ Internal Representation and Key Implementation Points.
 	value:		<Object>
 "
 Class {
-	#name : #SeamlessLocalVariableState,
-	#superclass : #SeamlessTransferObject,
+	#name : 'SeamlessLocalVariableState',
+	#superclass : 'SeamlessTransferObject',
 	#instVars : [
 		'remoteVariable',
 		'value',
 		'isAssigned'
 	],
-	#category : #'Seamless-Core'
+	#category : 'Seamless-Core',
+	#package : 'Seamless',
+	#tag : 'Core'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessLocalVariableState class >> of: aRemoteVariable [
 	^self new 
 		remoteVariable: aRemoteVariable
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessLocalVariableState >> checkConnection [
 	remoteVariable ifNil: [ ^false].
 	
@@ -38,37 +40,37 @@ SeamlessLocalVariableState >> checkConnection [
 	^false
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SeamlessLocalVariableState >> initialize [
 	super initialize.
 	
 	isAssigned := false
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessLocalVariableState >> isAssigned [
 	^ isAssigned
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessLocalVariableState >> isAssigned: anObject [
 	isAssigned := anObject
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessLocalVariableState >> isUnassigned [
 
 	^isAssigned not
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessLocalVariableState >> prepareValueTransferBy: aSeamlessTransporter [
 
 	remoteVariable ifNotNil: [ 
 		aSeamlessTransporter transferByReference: remoteVariable]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessLocalVariableState >> read [
 
 	self checkConnection ifFalse: [ ^value].
@@ -80,7 +82,7 @@ SeamlessLocalVariableState >> read [
 	^self readRemoteValue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessLocalVariableState >> readRemoteValue [
 	"It is possible that remote request will be delivered to remote side but response will hangs.
 	We should setup timeout in that case and ignore possible value update"
@@ -92,30 +94,30 @@ SeamlessLocalVariableState >> readRemoteValue [
 	^value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessLocalVariableState >> remoteVariable [
 	^ remoteVariable
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessLocalVariableState >> remoteVariable: anObject [
 	remoteVariable := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessLocalVariableState >> value [
 
 	^value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessLocalVariableState >> value: anObject [
 
 	value := anObject.
 	isAssigned := true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessLocalVariableState >> write: anObject [
 	| writeMessage |
 	self value: anObject.

--- a/Seamless/SeamlessMessageSendRequest.class.st
+++ b/Seamless/SeamlessMessageSendRequest.class.st
@@ -2,17 +2,19 @@
 I am request to execute remote message send (my valuable variable is MessageSend instance)
 "
 Class {
-	#name : #SeamlessMessageSendRequest,
-	#superclass : #SeamlessEvaluationRequest,
-	#category : #'Seamless-Requests'
+	#name : 'SeamlessMessageSendRequest',
+	#superclass : 'SeamlessEvaluationRequest',
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessMessageSendRequest >> messageSend [
 	^ valuable
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SeamlessMessageSendRequest >> printMessageForLog [
 
 	^String streamContents: [ :s | 
@@ -23,7 +25,7 @@ SeamlessMessageSendRequest >> printMessageForLog [
 	]
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SeamlessMessageSendRequest >> printOn: aStream [
 
 	super printOn: aStream.
@@ -35,12 +37,12 @@ SeamlessMessageSendRequest >> printOn: aStream [
 		nextPut: $)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessMessageSendRequest >> receiver [
 	^self messageSend receiver
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessMessageSendRequest >> selector [
 	^self messageSend selector
 ]

--- a/Seamless/SeamlessMissingGlobal.class.st
+++ b/Seamless/SeamlessMissingGlobal.class.st
@@ -9,31 +9,33 @@ Internal Representation and Key Implementation Points.
 	name:		<String>
 "
 Class {
-	#name : #SeamlessMissingGlobal,
-	#superclass : #SeamlessTransferObject,
+	#name : 'SeamlessMissingGlobal',
+	#superclass : 'SeamlessTransferObject',
 	#instVars : [
 		'name'
 	],
-	#category : 'Seamless-Core'
+	#category : 'Seamless-Core',
+	#package : 'Seamless',
+	#tag : 'Core'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessMissingGlobal class >> named: aString [
 	^self new 
 		name: aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessMissingGlobal >> name [
 	^ name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessMissingGlobal >> name: anObject [
 	name := anObject
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SeamlessMissingGlobal >> printOn: aStream [
 	super printOn: aStream.
 	aStream nextPut: $(.
@@ -41,7 +43,7 @@ SeamlessMissingGlobal >> printOn: aStream [
 	aStream nextPut: $).
 ]
 
-{ #category : #'transfer strategies' }
+{ #category : 'transfer strategies' }
 SeamlessMissingGlobal >> seamlessDefaultTransferStrategy [ 
 
 	^SeamlessTransferStrategy defaultByGlobalName 

--- a/Seamless/SeamlessMissingObject.class.st
+++ b/Seamless/SeamlessMissingObject.class.st
@@ -8,38 +8,40 @@ Internal Representation and Key Implementation Points.
 	reference:		<SeamlessObjectReference>
 "
 Class {
-	#name : #SeamlessMissingObject,
-	#superclass : #SeamlessTransferObject,
+	#name : 'SeamlessMissingObject',
+	#superclass : 'SeamlessTransferObject',
 	#instVars : [
 		'reference'
 	],
-	#category : 'Seamless-Core'
+	#category : 'Seamless-Core',
+	#package : 'Seamless',
+	#tag : 'Core'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessMissingObject class >> referencedBy: aSeamlessObjectReference [
 	^self new 
 		reference: aSeamlessObjectReference 
 ]
 
-{ #category : #'messages processing' }
+{ #category : 'messages processing' }
 SeamlessMissingObject >> perform: aSelector [
 
 	SeamlessReferencedObjectIsLost signal
 ]
 
-{ #category : #'messages processing' }
+{ #category : 'messages processing' }
 SeamlessMissingObject >> perform: selector withArguments: arguments [
 
 	SeamlessReferencedObjectIsLost signal
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessMissingObject >> reference [
 	^ reference
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessMissingObject >> reference: anObject [
 	reference := anObject
 ]

--- a/Seamless/SeamlessNetwork.class.st
+++ b/Seamless/SeamlessNetwork.class.st
@@ -57,8 +57,8 @@ Internal Representation and Key Implementation Points.
 
 "
 Class {
-	#name : #SeamlessNetwork,
-	#superclass : #BasysNetwork,
+	#name : 'SeamlessNetwork',
+	#superclass : 'BasysNetwork',
 	#instVars : [
 		'distributedObjects',
 		'transferStrategies',
@@ -68,25 +68,27 @@ Class {
 	#classInstVars : [
 		'defaultRequestProcessingTimeout'
 	],
-	#category : #'Seamless-Core'
+	#category : 'Seamless-Core',
+	#package : 'Seamless',
+	#tag : 'Core'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNetwork class >> defaultRequestProcessingTimeout [
 	^defaultRequestProcessingTimeout
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNetwork class >> defaultRequestProcessingTimeout: aDuration [
 	defaultRequestProcessingTimeout := aDuration
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 SeamlessNetwork class >> defaultRequestProcessingTimeoutSecs [
 	^self defaultRequestProcessingTimeout ifNil: [ 0 ] ifNotNil: [:timeout | timeout asSeconds]
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 SeamlessNetwork class >> defaultRequestProcessingTimeoutSecs: aNumber [
 
 	| timeout |
@@ -95,7 +97,7 @@ SeamlessNetwork class >> defaultRequestProcessingTimeoutSecs: aNumber [
 	self defaultRequestProcessingTimeout: timeout
 ]
 
-{ #category : #settings }
+{ #category : 'settings' }
 SeamlessNetwork class >> settingOn: aBuilder [
 	<systemsettings>
 	(aBuilder group: #seamless)
@@ -109,36 +111,36 @@ SeamlessNetwork class >> settingOn: aBuilder [
 				] 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNetwork >> addTransferStrategy: aTransferStrategy [
 
 	transferStrategies add: aTransferStrategy 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNetwork >> addTransferStrategy: aTransferStrategy priority: anInteger [ 
 	aTransferStrategy priority: anInteger.
 	self addTransferStrategy: aTransferStrategy
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNetwork >> createDeliveryForResultFrom: aRemotePeer [
 	^ self requestProcessingTimeout
 			ifNil: [SeamlessRequestResultDelivery from: aRemotePeer]
 			ifNotNil: [:timeout |	SeamlessRequestResultTimelyDelivery from: aRemotePeer maxTime: timeout]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNetwork >> distributedObjects [
 	^ distributedObjects
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNetwork >> distributedObjects: anObject [
 	distributedObjects := anObject
 ]
 
-{ #category : #requests }
+{ #category : 'requests' }
 SeamlessNetwork >> environmentAt: anAddress [ 
 
 	| remotePeer |
@@ -146,7 +148,7 @@ SeamlessNetwork >> environmentAt: anAddress [
 	^remotePeer remoteEnvironment
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessNetwork >> identifyLocalPeerOn: aConnection [
 
 	| context |
@@ -156,7 +158,7 @@ SeamlessNetwork >> identifyLocalPeerOn: aConnection [
 	
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SeamlessNetwork >> initialize [
 	super initialize.
 	
@@ -165,12 +167,12 @@ SeamlessNetwork >> initialize [
 	transport := SeamlessTransport default
 ]
 
-{ #category : #factory }
+{ #category : 'factory' }
 SeamlessNetwork >> newRemotePeer [ 
 	^SeamlessRemotePeer inside: self
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNetwork >> objectFor: aSeamlessObjectReference [
 
 	^distributedObjects 
@@ -178,7 +180,7 @@ SeamlessNetwork >> objectFor: aSeamlessObjectReference [
 		ifAbsentUseProxy: [ aSeamlessObjectReference createProxy]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNetwork >> objectFor: aSeamlessObjectReference ifNotNew: presentBlock [
 
 	^distributedObjects 
@@ -187,36 +189,36 @@ SeamlessNetwork >> objectFor: aSeamlessObjectReference ifNotNew: presentBlock [
 		ifAbsentUseProxy: [ aSeamlessObjectReference createProxy]
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessNetwork >> process: aSeamlessRequest receivedFrom: aRemotePeer [
 	aSeamlessRequest executeFor: aRemotePeer
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessNetwork >> receiveObjectBy: aBasysConnection [
 
 	^transport receiveObjectFrom: aBasysConnection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNetwork >> referenceFor: anObject [
 
 	^self referenceFor: anObject ifNewUse: [ anObject createSeamlessReference]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNetwork >> referenceFor: anObject ifNewUse: refCreationBlock [
 
 	^distributedObjects referenceFor: anObject ifNewUse: refCreationBlock
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNetwork >> removeDistributedObject: anObject [
 
 	distributedObjects remove: anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNetwork >> removeRemotePeer: aRemotePeer [
 	super removeRemotePeer: aRemotePeer.
 	
@@ -224,35 +226,35 @@ SeamlessNetwork >> removeRemotePeer: aRemotePeer [
 	peerRegistry isEmpty ifTrue: [ distributedObjects clear ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNetwork >> requestProcessingTimeout [
 	^ requestProcessingTimeout ifNil: [self class defaultRequestProcessingTimeout]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNetwork >> requestProcessingTimeout: aDuration [
 	requestProcessingTimeout := aDuration
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessNetwork >> sendObject: aSeamlessRequest by: aBasysConnection [
 
 	transport sendObject: aSeamlessRequest to: aBasysConnection
 ]
 
-{ #category : #'transfer strategies' }
+{ #category : 'transfer strategies' }
 SeamlessNetwork >> transferByDeepCopy: objectsCriteria [
 
 	self addTransferStrategy: (SeamlessTransferByDeepCopyStrategy for: objectsCriteria)
 ]
 
-{ #category : #'transfer strategies' }
+{ #category : 'transfer strategies' }
 SeamlessNetwork >> transferByDefaultStrategy: objectsCriteria [
 
 	self addTransferStrategy: (SeamlessDefaultTransferStrategy for: objectsCriteria)
 ]
 
-{ #category : #'transfer strategies' }
+{ #category : 'transfer strategies' }
 SeamlessNetwork >> transferByDefaultStrategy: objectsCriteria priority: anInteger [
 
 	self
@@ -260,42 +262,42 @@ SeamlessNetwork >> transferByDefaultStrategy: objectsCriteria priority: anIntege
 		priority: anInteger
 ]
 
-{ #category : #'transfer strategies' }
+{ #category : 'transfer strategies' }
 SeamlessNetwork >> transferByReference: objectsCriteria [
 
 	self addTransferStrategy: (SeamlessTransferByReferenceStrategy for: objectsCriteria)
 ]
 
-{ #category : #'transfer strategies' }
+{ #category : 'transfer strategies' }
 SeamlessNetwork >> transferByReference: objectsCriteria withCacheFor: selectors [
 
 	self addTransferStrategy: (
 		SeamlessTransferByReferenceStrategy for: objectsCriteria withCacheFor: selectors)
 ]
 
-{ #category : #'transfer strategies' }
+{ #category : 'transfer strategies' }
 SeamlessNetwork >> transferByReferencedCopy: objectsCriteria [
 
 	self addTransferStrategy: (SeamlessTransferByReferencedCopyStrategy for: objectsCriteria)
 ]
 
-{ #category : #'transfer strategies' }
+{ #category : 'transfer strategies' }
 SeamlessNetwork >> transferByValue: objectsCriteria [
 
 	self addTransferStrategy: (SeamlessTransferByValueStrategy for: objectsCriteria)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNetwork >> transferStrategies [
 	^ transferStrategies
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNetwork >> transferStrategies: anObject [
 	transferStrategies := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNetwork >> transferStrategyFor: anObject [
 
 	anObject isOnlyDefaultTransferStrategyAllowed ifTrue: [ ^anObject seamlessDefaultTransferStrategy ].
@@ -303,12 +305,12 @@ SeamlessNetwork >> transferStrategyFor: anObject [
 	^transferStrategies detect: [ :each | each isAppliedTo: anObject ] ifNone: [ anObject seamlessDefaultTransferStrategy ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNetwork >> transport [
 	^ transport
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNetwork >> transport: anObject [
 	transport := anObject
 ]

--- a/Seamless/SeamlessNonLocalReturnResult.class.st
+++ b/Seamless/SeamlessNonLocalReturnResult.class.st
@@ -12,33 +12,35 @@ Internal Representation and Key Implementation Points.
 	value:		<Object>
 "
 Class {
-	#name : #SeamlessNonLocalReturnResult,
-	#superclass : #SeamlessRequestResult,
+	#name : 'SeamlessNonLocalReturnResult',
+	#superclass : 'SeamlessRequestResult',
 	#instVars : [
 		'homeContext',
 		'value'
 	],
-	#category : 'Seamless-Requests'
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessNonLocalReturnResult class >> with: anObject homeContext: aContext [
 	^self new 
 		value: anObject;
 		homeContext: aContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNonLocalReturnResult >> homeContext [
 	^ homeContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNonLocalReturnResult >> homeContext: anObject [
 	homeContext := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNonLocalReturnResult >> returnValue [
 	homeContext isSeamlessProxy ifTrue: [ 
 		^BlockCannotReturn result: value from: homeContext].
@@ -46,12 +48,12 @@ SeamlessNonLocalReturnResult >> returnValue [
 	homeContext return: value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNonLocalReturnResult >> value [
 	^value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessNonLocalReturnResult >> value: anObject [
 	value := anObject
 ]

--- a/Seamless/SeamlessObjectCopyReference.class.st
+++ b/Seamless/SeamlessObjectCopyReference.class.st
@@ -8,41 +8,43 @@ Internal Representation and Key Implementation Points.
 	objectCopy:		<Object>
 "
 Class {
-	#name : #SeamlessObjectCopyReference,
-	#superclass : #SeamlessObjectReference,
+	#name : 'SeamlessObjectCopyReference',
+	#superclass : 'SeamlessObjectReference',
 	#instVars : [
 		'objectCopy'
 	],
-	#category : 'Seamless-Core'
+	#category : 'Seamless-Core',
+	#package : 'Seamless',
+	#tag : 'Core'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessObjectCopyReference class >> to: anObject [
 	^self new 
 		objectCopy: anObject copy
 ]
 
-{ #category : #'proxy creation' }
+{ #category : 'proxy creation' }
 SeamlessObjectCopyReference >> createProxy [
 	^objectCopy
 ]
 
-{ #category : #'travel guide support' }
+{ #category : 'travel guide support' }
 SeamlessObjectCopyReference >> hasRemoteProperties [
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessObjectCopyReference >> objectCopy [
 	^ objectCopy
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessObjectCopyReference >> objectCopy: anObject [
 	objectCopy := anObject
 ]
 
-{ #category : #transfer }
+{ #category : 'transfer' }
 SeamlessObjectCopyReference >> prepareLocalSubstitutionIn: aSeamlessNetwork with: aSeamlessTransporter [
 	| representation |
 	objectCopy := aSeamlessTransporter readNextObject.
@@ -64,24 +66,24 @@ SeamlessObjectCopyReference >> prepareLocalSubstitutionIn: aSeamlessNetwork with
 	^representation
 ]
 
-{ #category : #transfer }
+{ #category : 'transfer' }
 SeamlessObjectCopyReference >> prepareValueTransferBy: aSeamlessTransporter [
 	super prepareValueTransferBy: aSeamlessTransporter.
 	
 	aSeamlessTransporter transferByValue: objectCopy 
 ]
 
-{ #category : #'travel guide support' }
+{ #category : 'travel guide support' }
 SeamlessObjectCopyReference >> remotePropertiesSize [
 	^1
 ]
 
-{ #category : #'travel guide support' }
+{ #category : 'travel guide support' }
 SeamlessObjectCopyReference >> remotePropertyAt: index [
 	^objectCopy
 ]
 
-{ #category : #'travel guide support' }
+{ #category : 'travel guide support' }
 SeamlessObjectCopyReference >> remotePropertyAt: index put: newObject [
 	objectCopy := newObject
 ]

--- a/Seamless/SeamlessObjectReference.class.st
+++ b/Seamless/SeamlessObjectReference.class.st
@@ -25,18 +25,20 @@ Public API and Key Messages
 	senderPeer:		<BasysPeer>
 "
 Class {
-	#name : #SeamlessObjectReference,
-	#superclass : #SeamlessTransferObject,
+	#name : 'SeamlessObjectReference',
+	#superclass : 'SeamlessTransferObject',
 	#instVars : [
 		'id',
 		'messagesCache',
 		'ownerPeerId',
 		'senderPeer'
 	],
-	#category : #'Seamless-Core'
+	#category : 'Seamless-Core',
+	#package : 'Seamless',
+	#tag : 'Core'
 }
 
-{ #category : #transfer }
+{ #category : 'transfer' }
 SeamlessObjectReference class >> createTostInstanceWith: aSeamlessTransporter [
 	| reference |
 	reference := super createTostInstanceWith: aSeamlessTransporter.
@@ -44,14 +46,14 @@ SeamlessObjectReference class >> createTostInstanceWith: aSeamlessTransporter [
 	^reference.
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessObjectReference class >> id: idObject peer: aBasysPeer [
 
 	^(self 	id: idObject peerId: aBasysPeer id)
 		senderPeer: aBasysPeer
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessObjectReference class >> id: objectId peerId: peerId [
 
 	^self new 
@@ -59,7 +61,7 @@ SeamlessObjectReference class >> id: objectId peerId: peerId [
 		ownerPeerId: peerId
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 SeamlessObjectReference >> = anObject [
 	"Answer whether the receiver and anObject represent the same object."
 
@@ -71,7 +73,7 @@ SeamlessObjectReference >> = anObject [
 		and: [ ownerPeerId = anObject ownerPeerId ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessObjectReference >> cacheMessage: selector with: resultObject [
 
 	messagesCache ifNil: [ messagesCache := SmallIdentityDictionary new].
@@ -79,40 +81,40 @@ SeamlessObjectReference >> cacheMessage: selector with: resultObject [
 	messagesCache at: selector put: resultObject	
 ]
 
-{ #category : #'proxy creation' }
+{ #category : 'proxy creation' }
 SeamlessObjectReference >> createProxy [
 	^SeamlessProxy for: self
 ]
 
-{ #category : #'travel guide support' }
+{ #category : 'travel guide support' }
 SeamlessObjectReference >> hasRemoteProperties [ 
 	^true
 ]
 
-{ #category : #comparing }
+{ #category : 'comparing' }
 SeamlessObjectReference >> hash [
 	"Answer an integer value that is related to the identity of the receiver."
 
 	^ id hash bitXor: ownerPeerId hash
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessObjectReference >> id [
 	^ id
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessObjectReference >> id: anObject [
 	id := anObject
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessObjectReference >> isConnectedToRemotePeer [
 
 	^senderPeer isConnected
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessObjectReference >> loadDeepCopy: aSeamlessProxy [
 
 	| context |
@@ -121,7 +123,7 @@ SeamlessObjectReference >> loadDeepCopy: aSeamlessProxy [
 	^context sendRequest: (SeamlessLoadDeepCopyRequest proxy: aSeamlessProxy)
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessObjectReference >> loadObject: aSeamlessProxy [
 
 	| context |
@@ -130,27 +132,27 @@ SeamlessObjectReference >> loadObject: aSeamlessProxy [
 	^context sendRequest: (SeamlessLoadObjectRequest proxy: aSeamlessProxy)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessObjectReference >> messagesCache [
 	^ messagesCache
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessObjectReference >> messagesCache: anObject [
 	messagesCache := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessObjectReference >> ownerPeerId [
 	^ ownerPeerId
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessObjectReference >> ownerPeerId: anObject [
 	ownerPeerId := anObject
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessObjectReference >> performAndCacheRemoteMessage: aMessageSend [
 
 	| result |
@@ -164,7 +166,7 @@ SeamlessObjectReference >> performAndCacheRemoteMessage: aMessageSend [
 	^result
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessObjectReference >> performRemoteMessage: aMessageSend [
 
 	messagesCache ifNotNil: [ 
@@ -173,7 +175,7 @@ SeamlessObjectReference >> performRemoteMessage: aMessageSend [
 	^self performRemoteMessageWithoutCache: aMessageSend
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessObjectReference >> performRemoteMessageWithoutCache: aMessageSend [
 
 	|  context |
@@ -183,13 +185,13 @@ SeamlessObjectReference >> performRemoteMessageWithoutCache: aMessageSend [
 	^context sendMessage: aMessageSend
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessObjectReference >> pointsToRemoteObject [
 
 	^senderPeer class ~~ BasysLocalPeer
 ]
 
-{ #category : #transfer }
+{ #category : 'transfer' }
 SeamlessObjectReference >> prepareLocalSubstitutionIn: aSeamlessNetwork with: aSeamlessTransporter [
 	| localObject |
 	super prepareLocalSubstitutionIn: aSeamlessNetwork with: aSeamlessTransporter.
@@ -199,13 +201,13 @@ SeamlessObjectReference >> prepareLocalSubstitutionIn: aSeamlessNetwork with: aS
 	^localObject
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SeamlessObjectReference >> printForSeamlessLog [
 
 	^'ObjectReference(', id asString, ')' 
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SeamlessObjectReference >> printOn: aStream [
 	| referenceName |
 	referenceName := 'an ObjectReference'.
@@ -220,37 +222,37 @@ SeamlessObjectReference >> printOn: aStream [
 		nextPut: $)
 ]
 
-{ #category : #'travel guide support' }
+{ #category : 'travel guide support' }
 SeamlessObjectReference >> remotePropertiesSize [
 	^1
 ]
 
-{ #category : #'travel guide support' }
+{ #category : 'travel guide support' }
 SeamlessObjectReference >> remotePropertyAt: propertyIndex [
 	^messagesCache
 ]
 
-{ #category : #'travel guide support' }
+{ #category : 'travel guide support' }
 SeamlessObjectReference >> remotePropertyAt: propertyIndex put: newObject [
 	messagesCache := newObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessObjectReference >> senderPeer [
 	^ senderPeer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessObjectReference >> senderPeer: anObject [
 	senderPeer := anObject
 ]
 
-{ #category : #'travel guide support' }
+{ #category : 'travel guide support' }
 SeamlessObjectReference >> travelGuide [
 	^SeamlessReferenceTravelGuide
 ]
 
-{ #category : #transfer }
+{ #category : 'transfer' }
 SeamlessObjectReference >> writeTostBodyWith: aSeamlessTransporter [
 
 	aSeamlessTransporter writeObjectReference: self

--- a/Seamless/SeamlessObjectValueContainer.class.st
+++ b/Seamless/SeamlessObjectValueContainer.class.st
@@ -9,31 +9,33 @@ Internal Representation and Key Implementation Points.
 	content:		<Object>
 "
 Class {
-	#name : #SeamlessObjectValueContainer,
-	#superclass : #SeamlessTransferObject,
+	#name : 'SeamlessObjectValueContainer',
+	#superclass : 'SeamlessTransferObject',
 	#instVars : [
 		'content'
 	],
-	#category : 'Seamless-Core'
+	#category : 'Seamless-Core',
+	#package : 'Seamless',
+	#tag : 'Core'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessObjectValueContainer class >> with: anObject [
 	^self new 
 		content: anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessObjectValueContainer >> content [
 	^ content
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessObjectValueContainer >> content: anObject [
 	content := anObject
 ]
 
-{ #category : #transfer }
+{ #category : 'transfer' }
 SeamlessObjectValueContainer >> prepareValueForTransferBy: aSeamlessTransporter [
 	"Container is always substituted by content while transferred over network.
 	it also commands transporter to transfer content by value"
@@ -43,7 +45,7 @@ SeamlessObjectValueContainer >> prepareValueForTransferBy: aSeamlessTransporter 
 	^content
 ]
 
-{ #category : #transfer }
+{ #category : 'transfer' }
 SeamlessObjectValueContainer >> prepareValueTransferBy: aSeamlessTransporter [
 	
 	aSeamlessTransporter transferByValue: content

--- a/Seamless/SeamlessPeerIdentificationContext.class.st
+++ b/Seamless/SeamlessPeerIdentificationContext.class.st
@@ -8,32 +8,34 @@ Internal Representation and Key Implementation Points.
 	connection:		<BasysConnection>
 "
 Class {
-	#name : #SeamlessPeerIdentificationContext,
-	#superclass : #SeamlessSyncRequestContext,
+	#name : 'SeamlessPeerIdentificationContext',
+	#superclass : 'SeamlessSyncRequestContext',
 	#instVars : [
 		'connection'
 	],
-	#category : 'Seamless-Requests'
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessPeerIdentificationContext class >> for: aBasysConnection [
 
 	^(self receiverPeer: aBasysConnection remotePeer)
 		connection: aBasysConnection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessPeerIdentificationContext >> connection [
 	^ connection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessPeerIdentificationContext >> connection: anObject [
 	connection := anObject
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SeamlessPeerIdentificationContext >> performRequestSend: aSeamlessRequest [
 	connection sendObject: aSeamlessRequest 
 ]

--- a/Seamless/SeamlessPeerIdentificationRequest.class.st
+++ b/Seamless/SeamlessPeerIdentificationRequest.class.st
@@ -6,21 +6,23 @@ For more details look at BasysNetwork comments
 	peerId:		<Object>
 "
 Class {
-	#name : #SeamlessPeerIdentificationRequest,
-	#superclass : #SeamlessRequest,
+	#name : 'SeamlessPeerIdentificationRequest',
+	#superclass : 'SeamlessRequest',
 	#instVars : [
 		'peerId'
 	],
-	#category : 'Seamless-Requests'
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessPeerIdentificationRequest class >> peerId: peerId [
 	^self new 
 		peerId: peerId
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SeamlessPeerIdentificationRequest >> executeFor: senderPeer [
 	
 	senderPeer ensureIdentity: peerId.
@@ -28,12 +30,12 @@ SeamlessPeerIdentificationRequest >> executeFor: senderPeer [
 	context returnValue: senderPeer localPeerId to: senderPeer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessPeerIdentificationRequest >> peerId [
 	^ peerId
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessPeerIdentificationRequest >> peerId: anObject [
 	peerId := anObject
 ]

--- a/Seamless/SeamlessProxy.class.st
+++ b/Seamless/SeamlessProxy.class.st
@@ -8,83 +8,85 @@ My behaviour delegates all messages to my reference object which resend all them
 	reference:		<SeamlessObjectReference>
 "
 Class {
-	#name : #SeamlessProxy,
-	#superclass : #GHObjectGhost,
+	#name : 'SeamlessProxy',
+	#superclass : 'GHObjectGhost',
 	#traits : 'GHTNotNilGhost + GHTIdentifiedGhost',
 	#classTraits : 'GHTNotNilGhost classTrait + GHTIdentifiedGhost classTrait',
 	#instVars : [
 		'reference'
 	],
-	#category : #'Seamless-Proxy'
+	#category : 'Seamless-Proxy',
+	#package : 'Seamless',
+	#tag : 'Proxy'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessProxy class >> for: aSeamlessObjectReference [ 
 
 	^self basicNew 
 		seamlessReference: aSeamlessObjectReference 
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessProxy >> asLocalDeepCopy [
 
 	^reference loadDeepCopy: self
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessProxy >> asLocalObject [
 
 	^reference loadObject: self
 ]
 
-{ #category : #transfer }
+{ #category : 'transfer' }
 SeamlessProxy >> asTransferredByDeepCopy [ 
 	^self
 ]
 
-{ #category : #transfer }
+{ #category : 'transfer' }
 SeamlessProxy >> asTransferredByValue [ 
 	^self
 ]
 
-{ #category : #'fuel support' }
+{ #category : 'fuel support' }
 SeamlessProxy >> fuelReplacement [
 	^ reference
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessProxy >> ghostBehaviour [
 	^SeamlessProxyBehaviour default
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SeamlessProxy >> ghostPrintString [
 
 	^(GHMetaMessages printObject: self), '(', reference id asString, ')'
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessProxy >> isConnectedToRemotePeer [
 
 	^reference isConnectedToRemotePeer
 ]
 
-{ #category : #transfer }
+{ #category : 'transfer' }
 SeamlessProxy >> isOnlyDefaultTransferStrategyAllowed [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessProxy >> isSeamlessProxy [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessProxy >> isTostValueObject [
 	^false
 ]
 
-{ #category : #'remote reflection' }
+{ #category : 'remote reflection' }
 SeamlessProxy >> nameForSeamlessStatistics [
 
 	| remoteName |
@@ -93,7 +95,7 @@ SeamlessProxy >> nameForSeamlessStatistics [
 	^'Remote ', remoteName
 ]
 
-{ #category : #'remote reflection' }
+{ #category : 'remote reflection' }
 SeamlessProxy >> performAndCacheRemoteMessage: aMessage [
 	| messageSend |
 	messageSend := 	MessageSend 
@@ -102,7 +104,7 @@ SeamlessProxy >> performAndCacheRemoteMessage: aMessage [
 	^reference performAndCacheRemoteMessage: messageSend
 ]
 
-{ #category : #'remote reflection' }
+{ #category : 'remote reflection' }
 SeamlessProxy >> performRemoteMessage: aMessage [
 	| messageSend |
 	messageSend := 	MessageSend 
@@ -111,19 +113,19 @@ SeamlessProxy >> performRemoteMessage: aMessage [
 	^reference performRemoteMessage: messageSend
 ]
 
-{ #category : #transfer }
+{ #category : 'transfer' }
 SeamlessProxy >> prepareValueForTransferBy: aSeamlessTransporter [
  	"proxies are always transferred as reference"
 	
 	^reference
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SeamlessProxy >> printForSeamlessLog [
 	^reference printForSeamlessLog 
 ]
 
-{ #category : #'remote reflection' }
+{ #category : 'remote reflection' }
 SeamlessProxy >> readRemoteSlot: aSlot [
 
 	| messageSend |
@@ -131,55 +133,55 @@ SeamlessProxy >> readRemoteSlot: aSlot [
 	^reference performRemoteMessageWithoutCache: messageSend
 ]
 
-{ #category : #'remote reflection' }
+{ #category : 'remote reflection' }
 SeamlessProxy >> remoteClass [
 
 	^self performAndCacheRemoteMessage: (Message selector: #class)
 ]
 
-{ #category : #'remote reflection' }
+{ #category : 'remote reflection' }
 SeamlessProxy >> remoteInstVarAt: index [
 
 	^self performRemoteMessage: (Message selector: #instVarAt: argument: index)
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessProxy >> remotePeer [
 	^reference senderPeer
 ]
 
-{ #category : #'remote reflection' }
+{ #category : 'remote reflection' }
 SeamlessProxy >> remotePrintString [
 
 	^self performRemoteMessage: (Message selector: #printString)
 ]
 
-{ #category : #transfer }
+{ #category : 'transfer' }
 SeamlessProxy >> seamlessDefaultTransferStrategy [ 
 	^SeamlessTransferStrategy defaultByValue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessProxy >> seamlessReference [
 	^ reference
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessProxy >> seamlessReference: aSeamlessObjectReference [
 	reference := aSeamlessObjectReference
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SeamlessProxy >> stDisplayString [
 	^self remotePrintString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessProxy >> travelGuide [
 	^EmptyObjectTravelGuide 
 ]
 
-{ #category : #'remote reflection' }
+{ #category : 'remote reflection' }
 SeamlessProxy >> writeRemoteSlot: aSlot value: anObject [
 
 	| messageSend |

--- a/Seamless/SeamlessProxyBehaviour.class.st
+++ b/Seamless/SeamlessProxyBehaviour.class.st
@@ -2,25 +2,27 @@
 I am behaviour for real Proxy implementation based on Ghost. I just delegate all intercepted messages to proxy seamless reference
 "
 Class {
-	#name : #SeamlessProxyBehaviour,
-	#superclass : #GHGhostBehaviour,
+	#name : 'SeamlessProxyBehaviour',
+	#superclass : 'GHGhostBehaviour',
 	#classInstVars : [
 		'default'
 	],
-	#category : 'Seamless-Proxy'
+	#category : 'Seamless-Proxy',
+	#package : 'Seamless',
+	#tag : 'Proxy'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessProxyBehaviour class >> default [
 	^default ifNil: [ default := self new ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessProxyBehaviour >> currentMetaLevel [
 	^GHMetaLevel standard
 ]
 
-{ #category : #'message interception' }
+{ #category : 'message interception' }
 SeamlessProxyBehaviour >> send: aMessage to: aSeamlessProxy [
 	
 	^aSeamlessProxy performRemoteMessage: aMessage

--- a/Seamless/SeamlessProxyWithoutTricks.class.st
+++ b/Seamless/SeamlessProxyWithoutTricks.class.st
@@ -7,49 +7,51 @@ But I delegate all message sends to my reference object which resend all them to
 	reference:		<SeamlessObjectReference>
 "
 Class {
-	#name : #SeamlessProxyWithoutTricks,
-	#superclass : #Object,
+	#name : 'SeamlessProxyWithoutTricks',
+	#superclass : 'Object',
 	#instVars : [
 		'reference'
 	],
-	#category : 'Seamless-Proxy'
+	#category : 'Seamless-Proxy',
+	#package : 'Seamless',
+	#tag : 'Proxy'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessProxyWithoutTricks class >> for: aSeamlessObjectReference [ 
 
 	^self new 
 		reference: aSeamlessObjectReference 
 ]
 
-{ #category : #'reflective operations' }
+{ #category : 'reflective operations' }
 SeamlessProxyWithoutTricks >> at: keyObject [
 
 	^self performRemoteMessage: (Message selector: #at: argument: keyObject)
 ]
 
-{ #category : #'reflective operations' }
+{ #category : 'reflective operations' }
 SeamlessProxyWithoutTricks >> doesNotUnderstand: aMessage [
 
 	^self performRemoteMessage: aMessage
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessProxyWithoutTricks >> isSeamlessProxy [
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessProxyWithoutTricks >> reference [
 	^ reference
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessProxyWithoutTricks >> reference: anObject [
 	reference := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessProxyWithoutTricks >> seamlessReference [
 	^ reference
 ]

--- a/Seamless/SeamlessReferenceTravelGuide.class.st
+++ b/Seamless/SeamlessReferenceTravelGuide.class.st
@@ -11,27 +11,29 @@ Seamless references should define following protocol:
 I skip any other native references by inst vars. For example senderPeer variable will not be traversed. To support Tost serialization references encode internal state directly to stream in optimized way
 "
 Class {
-	#name : #SeamlessReferenceTravelGuide,
-	#superclass : #ObjectTravelGuide,
-	#category : 'Seamless-Core'
+	#name : 'SeamlessReferenceTravelGuide',
+	#superclass : 'ObjectTravelGuide',
+	#category : 'Seamless-Core',
+	#package : 'Seamless',
+	#tag : 'Core'
 }
 
-{ #category : #navigation }
+{ #category : 'navigation' }
 SeamlessReferenceTravelGuide class >> isNode: aSeamlessObjectReference hasLastReferenceAt: referenceIndex [
 	^referenceIndex > 0 and: [aSeamlessObjectReference remotePropertiesSize = referenceIndex]
 ]
 
-{ #category : #navigation }
+{ #category : 'navigation' }
 SeamlessReferenceTravelGuide class >> isNodeEmpty: aSeamlessObjectReference [
 	^aSeamlessObjectReference hasRemoteProperties not
 ]
 
-{ #category : #navigation }
+{ #category : 'navigation' }
 SeamlessReferenceTravelGuide class >> referenceOf: aSeamlessObjectReference atIndex: referenceIndex [
 	^aSeamlessObjectReference remotePropertyAt: referenceIndex
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessReferenceTravelGuide class >> replaceReferenceOf: aSeamlessObjectReference at: referenceIndex with: replacementObject [
 	^aSeamlessObjectReference remotePropertyAt: referenceIndex put: replacementObject 
 ]

--- a/Seamless/SeamlessReferencedObjectIsLost.class.st
+++ b/Seamless/SeamlessReferencedObjectIsLost.class.st
@@ -2,12 +2,14 @@
 I am error for case when client send message to object which is not anymore exists on server
 "
 Class {
-	#name : #SeamlessReferencedObjectIsLost,
-	#superclass : #Error,
-	#category : 'Seamless-Core'
+	#name : 'SeamlessReferencedObjectIsLost',
+	#superclass : 'Error',
+	#category : 'Seamless-Core',
+	#package : 'Seamless',
+	#tag : 'Core'
 }
 
-{ #category : #converting }
+{ #category : 'converting' }
 SeamlessReferencedObjectIsLost >> handleSeamlessRequest: anEvaluationRequest receivedFrom: senderPeer [
 	| result |
 	result := SeamlessThrowExceptionResult with: self.
@@ -15,12 +17,12 @@ SeamlessReferencedObjectIsLost >> handleSeamlessRequest: anEvaluationRequest rec
 	anEvaluationRequest returnResult: result to: senderPeer
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessReferencedObjectIsLost >> isOnlyDefaultTransferStrategyAllowed [
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessReferencedObjectIsLost >> seamlessDefaultTransferStrategy [ 
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/SeamlessRemoteContext.class.st
+++ b/Seamless/SeamlessRemoteContext.class.st
@@ -4,12 +4,14 @@ On local side requests contain SeamlessRequestSendingContext. This contexts can 
 As proxy I can resend my messages to my remote sender peer.  I use it to implement return method. I just send new SeamlessMessageSendRequest with me as receiver of #return: message
 "
 Class {
-	#name : #SeamlessRemoteContext,
-	#superclass : #SeamlessRequestContext,
-	#category : 'Seamless-Requests'
+	#name : 'SeamlessRemoteContext',
+	#superclass : 'SeamlessRequestContext',
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessRemoteContext >> return: aSeamlessRequestResult to: senderPeer [
 	
 	| deliveryRequest |

--- a/Seamless/SeamlessRemoteException.class.st
+++ b/Seamless/SeamlessRemoteException.class.st
@@ -6,19 +6,21 @@ I can be created by
 	SeamlessRemoteException for: originalException
 "
 Class {
-	#name : #SeamlessRemoteException,
-	#superclass : #Error,
-	#category : 'Seamless-Core'
+	#name : 'SeamlessRemoteException',
+	#superclass : 'Error',
+	#category : 'Seamless-Core',
+	#package : 'Seamless',
+	#tag : 'Core'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessRemoteException class >> for: anException [
 
 	^self new 	
 		messageText: anException printString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRemoteException >> seamlessDefaultTransferStrategy [ 
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/SeamlessRemotePeer.class.st
+++ b/Seamless/SeamlessRemotePeer.class.st
@@ -5,12 +5,14 @@ I extend a BasysRemotePeer with Seamless specific functionality:
 - evaluate a block on remote side
 "
 Class {
-	#name : #SeamlessRemotePeer,
-	#superclass : #BasysRemotePeer,
-	#category : #'Seamless-Core'
+	#name : 'SeamlessRemotePeer',
+	#superclass : 'BasysRemotePeer',
+	#category : 'Seamless-Core',
+	#package : 'Seamless',
+	#tag : 'Core'
 }
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 SeamlessRemotePeer >> close [
 	"This method is supposed to be used when you really want to close (destroy) the peer and release all resources independently if they are used anywhere in the network.
 	Special request is sent here to remote side to notify it. Then local and remote sides will clean all related resources, close connections and clean distributed objects.
@@ -19,37 +21,37 @@ SeamlessRemotePeer >> close [
 	super close
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 SeamlessRemotePeer >> closeByRemoteSide [
 
 	super close
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 SeamlessRemotePeer >> createResultDeliveryForRequests [
 
 	^network createDeliveryForResultFrom: self
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 SeamlessRemotePeer >> createSyncRequestContext [
 
 	^SeamlessSyncRequestContext receiverPeer: self
 ]
 
-{ #category : #requests }
+{ #category : 'requests' }
 SeamlessRemotePeer >> evaluate: aBlock [
 
 	^self createSyncRequestContext sendRequest: (SeamlessBlockEvaluationRequest with: aBlock)
 ]
 
-{ #category : #requests }
+{ #category : 'requests' }
 SeamlessRemotePeer >> evaluateAsync: aBlock [
 
 	self sendObject: (SeamlessBlockEvaluationRequest with: aBlock)
 ]
 
-{ #category : #requests }
+{ #category : 'requests' }
 SeamlessRemotePeer >> remoteEnvironment [
 
 	^self createSyncRequestContext sendRequest: SeamlessGetEnvironmentRequest new

--- a/Seamless/SeamlessRequest.class.st
+++ b/Seamless/SeamlessRequest.class.st
@@ -16,42 +16,44 @@ Public API and Key Messages
 	resultBytes:	<Integer>
 "
 Class {
-	#name : #SeamlessRequest,
-	#superclass : #Object,
+	#name : 'SeamlessRequest',
+	#superclass : 'Object',
 	#instVars : [
 		'context',
 		'resultBytes',
 		'ownBytes'
 	],
-	#category : 'Seamless-Requests'
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessRequest class >> definesWellKnownSeamlessClass [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessRequest class >> definesWellKnownSeamlessClassHierarchy [ 
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequest >> context [
 	^ context
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequest >> context: anObject [
 	context := anObject
 ]
 
-{ #category : #execution }
+{ #category : 'execution' }
 SeamlessRequest >> executeFor: senderPeer [
 	self subclassResponsibility 
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SeamlessRequest >> initialize [
 	super initialize.
 	
@@ -59,52 +61,52 @@ SeamlessRequest >> initialize [
 	ownBytes := resultBytes := 0
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessRequest >> isIncoming [
 	^self isOutgoing not
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessRequest >> isOnlyDefaultTransferStrategyAllowed [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessRequest >> isOutgoing [
 	^context isKindOf: SeamlessRequestSendingContext
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequest >> ownBytes [
 	^ ownBytes
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequest >> ownBytes: anObject [
 	ownBytes := anObject
 ]
 
-{ #category : #printing }
+{ #category : 'printing' }
 SeamlessRequest >> printMessageForLog [
 	^self printString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequest >> resultBytes [
 	^ resultBytes
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequest >> resultBytes: anObject [
 	resultBytes := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequest >> seamlessDefaultTransferStrategy [ 
 	^SeamlessTransferStrategy defaultByValue 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequest >> transferredBytes [
 	^ ownBytes + resultBytes
 ]

--- a/Seamless/SeamlessRequestContext.class.st
+++ b/Seamless/SeamlessRequestContext.class.st
@@ -15,40 +15,42 @@ Public API and Key Messages
 
 "
 Class {
-	#name : #SeamlessRequestContext,
-	#superclass : #Object,
+	#name : 'SeamlessRequestContext',
+	#superclass : 'Object',
 	#classVars : [
 		'Default'
 	],
-	#category : 'Seamless-Requests'
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequestContext class >> default [
 	^Default ifNil: [ Default := SeamlessDefaultRequestContext new ]
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessRequestContext class >> definesWellKnownSeamlessClass [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessRequestContext class >> definesWellKnownSeamlessClassHierarchy [ 
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessRequestContext >> isOnlyDefaultTransferStrategyAllowed [
 	^true
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessRequestContext >> return: aSeamlessRequestResult to: senderPeer [
 	self subclassResponsibility 
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessRequestContext >> returnValue: anObject to: senderPeer [
 
 	self return: (SeamlessReturnValueResult with: anObject) to: senderPeer

--- a/Seamless/SeamlessRequestContextReference.class.st
+++ b/Seamless/SeamlessRequestContextReference.class.st
@@ -3,17 +3,19 @@ I represent reference to distributed SeamlessRequestContext.
 On remote side I represent it by SeamlessRemoteContext
 "
 Class {
-	#name : #SeamlessRequestContextReference,
-	#superclass : #SeamlessObjectReference,
-	#category : 'Seamless-Core'
+	#name : 'SeamlessRequestContextReference',
+	#superclass : 'SeamlessObjectReference',
+	#category : 'Seamless-Core',
+	#package : 'Seamless',
+	#tag : 'Core'
 }
 
-{ #category : #'proxy creation' }
+{ #category : 'proxy creation' }
 SeamlessRequestContextReference >> createProxy [
 	^SeamlessRemoteContext new
 ]
 
-{ #category : #'travel guide support' }
+{ #category : 'travel guide support' }
 SeamlessRequestContextReference >> hasRemoteProperties [ 
 	^false
 ]

--- a/Seamless/SeamlessRequestResult.class.st
+++ b/Seamless/SeamlessRequestResult.class.st
@@ -17,51 +17,53 @@ Internal Representation and Key Implementation Points.
 	transferredBytes:		<Integer>
 "
 Class {
-	#name : #SeamlessRequestResult,
-	#superclass : #Object,
+	#name : 'SeamlessRequestResult',
+	#superclass : 'Object',
 	#instVars : [
 		'transferredBytes'
 	],
-	#category : 'Seamless-Requests'
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessRequestResult class >> definesWellKnownSeamlessClass [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessRequestResult class >> definesWellKnownSeamlessClassHierarchy [ 
 	^true
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SeamlessRequestResult >> initialize [
 	super initialize.
 	transferredBytes := 0
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequestResult >> isOnlyDefaultTransferStrategyAllowed [
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequestResult >> returnValue [ 
 	self subclassResponsibility 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequestResult >> seamlessDefaultTransferStrategy [ 
 	^SeamlessTransferStrategy defaultByValue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequestResult >> transferredBytes [
 	^ transferredBytes
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequestResult >> transferredBytes: anObject [
 	transferredBytes := anObject
 ]

--- a/Seamless/SeamlessRequestResultDelivery.class.st
+++ b/Seamless/SeamlessRequestResultDelivery.class.st
@@ -25,23 +25,25 @@ Internal Representation and Key Implementation Points.
 	synchronizationSemaphore:		<Semaphore>
 "
 Class {
-	#name : #SeamlessRequestResultDelivery,
-	#superclass : #Object,
+	#name : 'SeamlessRequestResultDelivery',
+	#superclass : 'Object',
 	#instVars : [
 		'senderPeer',
 		'synchronizationSemaphore',
 		'requestResult'
 	],
-	#category : #'Seamless-Requests'
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessRequestResultDelivery class >> from: aRemotePeer [
 	^self new 
 		senderPeer: aRemotePeer
 ]
 
-{ #category : #delivery }
+{ #category : 'delivery' }
 SeamlessRequestResultDelivery >> deliverResultFor: aRequest [
 
 	self waitResult.
@@ -51,36 +53,36 @@ SeamlessRequestResultDelivery >> deliverResultFor: aRequest [
 	^requestResult returnValue
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SeamlessRequestResultDelivery >> initialize [
 	super initialize.
 	
 	synchronizationSemaphore := Semaphore new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequestResultDelivery >> requestResult [
 	^ requestResult
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequestResultDelivery >> senderPeer [
 	^ senderPeer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequestResultDelivery >> senderPeer: anObject [
 	senderPeer := anObject
 ]
 
-{ #category : #delivery }
+{ #category : 'delivery' }
 SeamlessRequestResultDelivery >> shipResult: aRequestResult [
 
 	requestResult := aRequestResult.
 	synchronizationSemaphore signal
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SeamlessRequestResultDelivery >> waitResult [
 	"Instead of blindly wait for delivery result forever we periodically check the connection status
 	and consider the deliver as unavailable when senderPeer is not connected anymore.

--- a/Seamless/SeamlessRequestResultDelivery.class.st
+++ b/Seamless/SeamlessRequestResultDelivery.class.st
@@ -87,9 +87,9 @@ SeamlessRequestResultDelivery >> waitResult [
 	"Instead of blindly wait for delivery result forever we periodically check the connection status
 	and consider the deliver as unavailable when senderPeer is not connected anymore.
 	So we fail as soon as senderPeer losts connection which improves responsiveness in bad scenarios"
-	
-	[requestResult isNil and: [ senderPeer isConnected ] ]
-		whileTrue: [ synchronizationSemaphore wait: 100 milliSeconds].
-		
+
+	[ requestResult isNil and: [ senderPeer isConnected ] ] whileTrue: [
+		synchronizationSemaphore waitTimeoutMilliseconds: 100 ].
+
 	requestResult ifNil: [ SeamlessResultDeliveryUnavailable signal ]
 ]

--- a/Seamless/SeamlessRequestResultTimelyDelivery.class.st
+++ b/Seamless/SeamlessRequestResultTimelyDelivery.class.st
@@ -7,31 +7,33 @@ Internal Representation and Key Implementation Points.
 	maxTime:		<Duration>
 "
 Class {
-	#name : #SeamlessRequestResultTimelyDelivery,
-	#superclass : #SeamlessRequestResultDelivery,
+	#name : 'SeamlessRequestResultTimelyDelivery',
+	#superclass : 'SeamlessRequestResultDelivery',
 	#instVars : [
 		'maxTime'
 	],
-	#category : #'Seamless-Requests'
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessRequestResultTimelyDelivery class >> from: aRemotePeer maxTime: aDuration [
 	^(self from: aRemotePeer)
 		maxTime: aDuration
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequestResultTimelyDelivery >> maxTime [
 	^ maxTime
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequestResultTimelyDelivery >> maxTime: anObject [
 	maxTime := anObject
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SeamlessRequestResultTimelyDelivery >> waitResult [
 	"Instead of blindly wait for delivery result for specified maxTime 
 	we periodically check the connection status

--- a/Seamless/SeamlessRequestResultTimelyDelivery.class.st
+++ b/Seamless/SeamlessRequestResultTimelyDelivery.class.st
@@ -44,7 +44,7 @@ SeamlessRequestResultTimelyDelivery >> waitResult [
 	
 	[DateAndTime now - startTime < maxTime 
 		and: [ requestResult isNil and: [ senderPeer isConnected ]] ]
-			whileTrue: [ synchronizationSemaphore wait: 100 milliSeconds].
+			whileTrue: [ synchronizationSemaphore waitTimeoutMilliseconds: 100 ].
 		
 	requestResult ifNil: [ 
 		DateAndTime now - startTime >= maxTime 

--- a/Seamless/SeamlessRequestSendingContext.class.st
+++ b/Seamless/SeamlessRequestSendingContext.class.st
@@ -14,48 +14,50 @@ Public API and Key Messages
 	receiverPeer:		<BasysRemotePeer>
 "
 Class {
-	#name : #SeamlessRequestSendingContext,
-	#superclass : #SeamlessRequestContext,
+	#name : 'SeamlessRequestSendingContext',
+	#superclass : 'SeamlessRequestContext',
 	#instVars : [
 		'receiverPeer'
 	],
-	#category : 'Seamless-Requests'
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessRequestSendingContext class >> receiverPeer: aRemotePeer [
 
 	^self new 
 		receiverPeer: aRemotePeer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequestSendingContext >> network [
 	^receiverPeer network
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequestSendingContext >> receiverPeer [
 	^ receiverPeer
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessRequestSendingContext >> receiverPeer: anObject [
 	receiverPeer := anObject
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessRequestSendingContext >> return: aSeamlessRequestResult [
 	self subclassResponsibility 
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessRequestSendingContext >> return: aSeamlessRequestResult to: senderPeer [
 
 	self return: aSeamlessRequestResult
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessRequestSendingContext >> sendRequest: aSeamlessRequest [
 	self subclassResponsibility 
 ]

--- a/Seamless/SeamlessRequestTimeout.class.st
+++ b/Seamless/SeamlessRequestTimeout.class.st
@@ -2,7 +2,9 @@
 I represent a timeout error when request processing took too much time or in other words when result was not delivered during specified maximum time 
 "
 Class {
-	#name : #SeamlessRequestTimeout,
-	#superclass : #Error,
-	#category : #'Seamless-Requests'
+	#name : 'SeamlessRequestTimeout',
+	#superclass : 'Error',
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }

--- a/Seamless/SeamlessResultDeliveryUnavailable.class.st
+++ b/Seamless/SeamlessResultDeliveryUnavailable.class.st
@@ -6,7 +6,9 @@ Delivery requires a ready connection with senderPeer. When it does not exist or 
 I am signalled by SeamlessRequestResultDelivery and subclasses during #waitResult logic.
 "
 Class {
-	#name : #SeamlessResultDeliveryUnavailable,
-	#superclass : #Error,
-	#category : #'Seamless-Requests'
+	#name : 'SeamlessResultDeliveryUnavailable',
+	#superclass : 'Error',
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }

--- a/Seamless/SeamlessReturnValueResult.class.st
+++ b/Seamless/SeamlessReturnValueResult.class.st
@@ -9,31 +9,33 @@ Internal Representation and Key Implementation Points.
 	value:		<Object>
 "
 Class {
-	#name : #SeamlessReturnValueResult,
-	#superclass : #SeamlessRequestResult,
+	#name : 'SeamlessReturnValueResult',
+	#superclass : 'SeamlessRequestResult',
 	#instVars : [
 		'value'
 	],
-	#category : 'Seamless-Requests'
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessReturnValueResult class >> with: anObject [ 
 	^self new 
 		value: anObject
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 SeamlessReturnValueResult >> returnValue [
 	^value
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 SeamlessReturnValueResult >> value [
 	^value
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessReturnValueResult >> value: anObject [
 	value := anObject
 ]

--- a/Seamless/SeamlessSubstitutionTostFormat.class.st
+++ b/Seamless/SeamlessSubstitutionTostFormat.class.st
@@ -6,24 +6,26 @@ By default it is objects themselfs. And in such cases I pass given object furthe
 In other cases it could be SeamlessObjectReference which I will write on stream instead of original objects. It is the way how transfer by reference strategy is executed
 "
 Class {
-	#name : #SeamlessSubstitutionTostFormat,
-	#superclass : #TostFormat,
-	#category : 'Seamless-Transport'
+	#name : 'SeamlessSubstitutionTostFormat',
+	#superclass : 'TostFormat',
+	#category : 'Seamless-Transport',
+	#package : 'Seamless',
+	#tag : 'Transport'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessSubstitutionTostFormat class >> network: aSeamlessNetwork [
 	^self new 
 		network: aSeamlessNetwork
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessSubstitutionTostFormat >> readObjectWith: aSeamlessTransporter [
 
 	^aSeamlessTransporter readObjectSubstitution 
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessSubstitutionTostFormat >> tryWriteObject: anObject with: aSeamlessTransporter [
 	
 	^aSeamlessTransporter tryWriteTransferObjectFor: anObject format: id

--- a/Seamless/SeamlessSyncRequestContext.class.st
+++ b/Seamless/SeamlessSyncRequestContext.class.st
@@ -12,42 +12,44 @@ Internal Representation and Key Implementation Points.
 	resultDelivery		<SeamlessRequestResultDelivery>
 "
 Class {
-	#name : #SeamlessSyncRequestContext,
-	#superclass : #SeamlessRequestSendingContext,
+	#name : 'SeamlessSyncRequestContext',
+	#superclass : 'SeamlessRequestSendingContext',
 	#instVars : [
 		'senderProcess',
 		'resultDelivery'
 	],
-	#category : #'Seamless-Requests'
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessSyncRequestContext >> createSeamlessReference [
 	^SeamlessRequestContextReference new
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 SeamlessSyncRequestContext >> performRequestSend: aSeamlessRequest [
 	receiverPeer sendObject: aSeamlessRequest 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessSyncRequestContext >> receiverPeer: anObject [
 	super receiverPeer: anObject.
 	resultDelivery := receiverPeer createResultDeliveryForRequests 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessSyncRequestContext >> resultDelivery [
 	^ resultDelivery
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessSyncRequestContext >> resultDelivery: anObject [
 	resultDelivery := anObject
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessSyncRequestContext >> return: aSeamlessRequestResult [
 
 	resultDelivery shipResult: aSeamlessRequestResult.
@@ -55,13 +57,13 @@ SeamlessSyncRequestContext >> return: aSeamlessRequestResult [
 	self network removeDistributedObject: self
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessSyncRequestContext >> sendMessage: aMessageSend [
 
 	^self sendRequest: (SeamlessMessageSendRequest with: aMessageSend)
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessSyncRequestContext >> sendRequest: aSeamlessRequest [ 
 
 	aSeamlessRequest context: self.
@@ -72,12 +74,12 @@ SeamlessSyncRequestContext >> sendRequest: aSeamlessRequest [
 	^resultDelivery deliverResultFor: aSeamlessRequest
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessSyncRequestContext >> senderProcess [
 	^ senderProcess
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessSyncRequestContext >> senderProcess: anObject [
 	senderProcess := anObject
 ]

--- a/Seamless/SeamlessThrowExceptionResult.class.st
+++ b/Seamless/SeamlessThrowExceptionResult.class.st
@@ -9,32 +9,34 @@ Internal Representation and Key Implementation Points.
 	exception:		<Exception>
 "
 Class {
-	#name : #SeamlessThrowExceptionResult,
-	#superclass : #SeamlessRequestResult,
+	#name : 'SeamlessThrowExceptionResult',
+	#superclass : 'SeamlessRequestResult',
 	#instVars : [
 		'exception'
 	],
-	#category : 'Seamless-Requests'
+	#category : 'Seamless-Requests',
+	#package : 'Seamless',
+	#tag : 'Requests'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessThrowExceptionResult class >> with: anException [
 
 	^self new 
 		exception: anException
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessThrowExceptionResult >> exception [
 	^ exception
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessThrowExceptionResult >> exception: anObject [
 	exception := anObject
 ]
 
-{ #category : #evaluating }
+{ #category : 'evaluating' }
 SeamlessThrowExceptionResult >> returnValue [
 
 	exception signal

--- a/Seamless/SeamlessTransferByDeepCopyStrategy.class.st
+++ b/Seamless/SeamlessTransferByDeepCopyStrategy.class.st
@@ -5,12 +5,14 @@ I have default instance:
 	SeamlessTransferStrategy defaultByDeepCopy
 "
 Class {
-	#name : #SeamlessTransferByDeepCopyStrategy,
-	#superclass : #SeamlessTransferStrategy,
-	#category : 'Seamless-Transport'
+	#name : 'SeamlessTransferByDeepCopyStrategy',
+	#superclass : 'SeamlessTransferStrategy',
+	#category : 'Seamless-Transport',
+	#package : 'Seamless',
+	#tag : 'Transport'
 }
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessTransferByDeepCopyStrategy >> prepareTransferObjectFor: anObject by: anObjectTransporter [
 
 	anObjectTransporter transferByDeepCopy: anObject.

--- a/Seamless/SeamlessTransferByGlobalNameStrategy.class.st
+++ b/Seamless/SeamlessTransferByGlobalNameStrategy.class.st
@@ -5,12 +5,14 @@ I have default instance:
 	SeamlessTransferStrategy defaultByGlobalName
 "
 Class {
-	#name : #SeamlessTransferByGlobalNameStrategy,
-	#superclass : #SeamlessTransferStrategy,
-	#category : 'Seamless-Transport'
+	#name : 'SeamlessTransferByGlobalNameStrategy',
+	#superclass : 'SeamlessTransferStrategy',
+	#category : 'Seamless-Transport',
+	#package : 'Seamless',
+	#tag : 'Transport'
 }
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessTransferByGlobalNameStrategy >> prepareTransferObjectFor: anObject by: anObjectTransporter [
 	
 	^SeamlessWellKnownObject named: anObject name

--- a/Seamless/SeamlessTransferByReferenceStrategy.class.st
+++ b/Seamless/SeamlessTransferByReferenceStrategy.class.st
@@ -5,39 +5,41 @@ I have default instance:
 	SeamlessTransferStrategy defaultByReference
 "
 Class {
-	#name : #SeamlessTransferByReferenceStrategy,
-	#superclass : #SeamlessTransferStrategy,
+	#name : 'SeamlessTransferByReferenceStrategy',
+	#superclass : 'SeamlessTransferStrategy',
 	#instVars : [
 		'cachePolicy',
 		'cachedMessages'
 	],
-	#category : 'Seamless-Transport'
+	#category : 'Seamless-Transport',
+	#package : 'Seamless',
+	#tag : 'Transport'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessTransferByReferenceStrategy class >> for: criteria withCacheFor: selectors [ 
 	^(self for: criteria) 
 		cachedMessages: selectors
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessTransferByReferenceStrategy >> cachedMessages [
 	^cachedMessages
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessTransferByReferenceStrategy >> cachedMessages: selectors [
 	cachedMessages := selectors
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SeamlessTransferByReferenceStrategy >> initialize [
 	super initialize.
 	
 	cachedMessages := Array empty
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessTransferByReferenceStrategy >> prepareTransferObjectFor: anObject by: anObjectTransporter [
  
 	| reference |

--- a/Seamless/SeamlessTransferByReferencedCopyStrategy.class.st
+++ b/Seamless/SeamlessTransferByReferencedCopyStrategy.class.st
@@ -2,12 +2,14 @@
 I am strategy which transfer objects by referenced copy which means that remote side will contain copy of original object which will be connected by me to client side object
 "
 Class {
-	#name : #SeamlessTransferByReferencedCopyStrategy,
-	#superclass : #SeamlessTransferStrategy,
-	#category : 'Seamless-Transport'
+	#name : 'SeamlessTransferByReferencedCopyStrategy',
+	#superclass : 'SeamlessTransferStrategy',
+	#category : 'Seamless-Transport',
+	#package : 'Seamless',
+	#tag : 'Transport'
 }
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessTransferByReferencedCopyStrategy >> prepareTransferObjectFor: anObject by: anObjectTransporter [
 	
 	^anObjectTransporter referenceFor: anObject ifNewUse: [SeamlessObjectCopyReference to: anObject]

--- a/Seamless/SeamlessTransferByValueStrategy.class.st
+++ b/Seamless/SeamlessTransferByValueStrategy.class.st
@@ -9,12 +9,14 @@ I have default instance:
 	SeamlessTransferStrategy defaultByValue
 "
 Class {
-	#name : #SeamlessTransferByValueStrategy,
-	#superclass : #SeamlessTransferStrategy,
-	#category : 'Seamless-Transport'
+	#name : 'SeamlessTransferByValueStrategy',
+	#superclass : 'SeamlessTransferStrategy',
+	#category : 'Seamless-Transport',
+	#package : 'Seamless',
+	#tag : 'Transport'
 }
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessTransferByValueStrategy >> prepareTransferObjectFor: anObject by: anObjectTransporter [
 	"By default transporter transfer given object by value. So we don't need to do anything here.
 	But we allow objects to specify default meaning of value transfer. 

--- a/Seamless/SeamlessTransferObject.class.st
+++ b/Seamless/SeamlessTransferObject.class.st
@@ -4,27 +4,29 @@ I am root class for objects which are used for transfer and substitute other nor
 I define that my subclasses should always and only transferred by value
 "
 Class {
-	#name : #SeamlessTransferObject,
-	#superclass : #Object,
-	#category : 'Seamless-Core'
+	#name : 'SeamlessTransferObject',
+	#superclass : 'Object',
+	#category : 'Seamless-Core',
+	#package : 'Seamless',
+	#tag : 'Core'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessTransferObject class >> definesWellKnownSeamlessClass [
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessTransferObject class >> definesWellKnownSeamlessClassHierarchy [ 
 	^true
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessTransferObject >> isOnlyDefaultTransferStrategyAllowed [
 	^true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessTransferObject >> seamlessDefaultTransferStrategy [ 
 	^SeamlessTransferStrategy defaultByValue 
 ]

--- a/Seamless/SeamlessTransferStrategy.class.st
+++ b/Seamless/SeamlessTransferStrategy.class.st
@@ -31,8 +31,8 @@ Internal Representation and Key Implementation Points.
 	criteria:		<Object>	which understands #matches: message. It can be StateSpecs objects
 "
 Class {
-	#name : #SeamlessTransferStrategy,
-	#superclass : #Object,
+	#name : 'SeamlessTransferStrategy',
+	#superclass : 'Object',
 	#instVars : [
 		'criteria',
 		'priority'
@@ -40,40 +40,42 @@ Class {
 	#classInstVars : [
 		'default'
 	],
-	#category : 'Seamless-Transport'
+	#category : 'Seamless-Transport',
+	#package : 'Seamless',
+	#tag : 'Transport'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessTransferStrategy class >> default [
 	^default ifNil: [ default := self new ]
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 SeamlessTransferStrategy class >> defaultByDeepCopy [
 	^ SeamlessTransferByDeepCopyStrategy default
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 SeamlessTransferStrategy class >> defaultByGlobalName [
 	^ SeamlessTransferByGlobalNameStrategy default
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 SeamlessTransferStrategy class >> defaultByReference [
 	^ SeamlessTransferByReferenceStrategy default
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 SeamlessTransferStrategy class >> defaultByReferencedCopy [
 	^ SeamlessTransferByReferencedCopyStrategy default
 ]
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 SeamlessTransferStrategy class >> defaultByValue [
 	^ SeamlessTransferByValueStrategy default
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessTransferStrategy class >> for: criteriaObjectSpec [
 
 	^self new 
@@ -81,40 +83,40 @@ SeamlessTransferStrategy class >> for: criteriaObjectSpec [
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessTransferStrategy >> criteria [
 	^ criteria
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessTransferStrategy >> criteria: anObject [
 	criteria := anObject
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SeamlessTransferStrategy >> initialize [
 	super initialize.
 	priority := 0
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessTransferStrategy >> isAppliedTo: anObject [
 	criteria ifNil: [ ^false ].
 	
 	^criteria matches: anObject
 ]
 
-{ #category : #operations }
+{ #category : 'operations' }
 SeamlessTransferStrategy >> prepareTransferObjectFor: anObject by: anObjectTransporter [
 	self subclassResponsibility 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessTransferStrategy >> priority [
 	^ priority
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessTransferStrategy >> priority: anObject [
 	priority := anObject
 ]

--- a/Seamless/SeamlessTransport.class.st
+++ b/Seamless/SeamlessTransport.class.st
@@ -10,15 +10,17 @@ SeamlessNetwork uses my #default instance as a transprot for requests:
 	transport receiveObjectFrom: aBasicConnection
 "
 Class {
-	#name : #SeamlessTransport,
-	#superclass : #TostTransport,
+	#name : 'SeamlessTransport',
+	#superclass : 'TostTransport',
 	#classInstVars : [
 		'default'
 	],
-	#category : #'Seamless-Transport'
+	#category : 'Seamless-Transport',
+	#package : 'Seamless',
+	#tag : 'Transport'
 }
 
-{ #category : #default }
+{ #category : 'default' }
 SeamlessTransport class >> collectWellKnownClasses [
 
 	| wellKnownClasses |
@@ -29,7 +31,7 @@ SeamlessTransport class >> collectWellKnownClasses [
 	^wellKnownClasses asArray
 ]
 
-{ #category : #default }
+{ #category : 'default' }
 SeamlessTransport class >> collectWellKnownObjects [
 
 	^TostWellKnownObjectFormat default objects, 
@@ -40,7 +42,7 @@ SeamlessTransport class >> collectWellKnownObjects [
 		allInstVarNames allSlots) asSet asArray
 ]
 
-{ #category : #default }
+{ #category : 'default' }
 SeamlessTransport class >> createDefault [
 
 	^default := self new 
@@ -53,25 +55,25 @@ SeamlessTransport class >> createDefault [
 			TostNewObjectOfNewClassFormat new }
 ]
 
-{ #category : #default }
+{ #category : 'default' }
 SeamlessTransport class >> default [
 	^default ifNil: [self createDefault]
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessTransport class >> forTransferOver: aSeamlessNetwork by: aRemotePeer [
 	^self new
 		network: aSeamlessNetwork;
 		remotePeer: aRemotePeer
 ]
 
-{ #category : #default }
+{ #category : 'default' }
 SeamlessTransport class >> resetDefault [
 
 	^default := nil
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SeamlessTransport >> newTransporterOn: aBasysConnection [
 
 	^SeamlessTransporter using: self onConnection: aBasysConnection

--- a/Seamless/SeamlessTransporter.class.st
+++ b/Seamless/SeamlessTransporter.class.st
@@ -33,8 +33,8 @@ Internal Representation and Key Implementation Points.
 	objectsByDeepCopy:		<IdentityDictionary>
 "
 Class {
-	#name : #SeamlessTransporter,
-	#superclass : #TostTransporter,
+	#name : 'SeamlessTransporter',
+	#superclass : 'TostTransporter',
 	#instVars : [
 		'network',
 		'connection',
@@ -44,17 +44,19 @@ Class {
 	#classInstVars : [
 		'default'
 	],
-	#category : #'Seamless-Transport'
+	#category : 'Seamless-Transport',
+	#package : 'Seamless',
+	#tag : 'Transport'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessTransporter class >> using: aSeamlessTransport onConnection: aBasysConnection [
 	^self new
 		transport: aSeamlessTransport;
 		connection: aBasysConnection
 ]
 
-{ #category : #sending }
+{ #category : 'sending' }
 SeamlessTransporter >> activateDeepCopyTransferIfNeeded [
 	| activeNode |
 	activeNode := self findActiveDeepCopyNodeAndIndex.
@@ -69,7 +71,7 @@ SeamlessTransporter >> activateDeepCopyTransferIfNeeded [
 	^false
 ]
 
-{ #category : #sending }
+{ #category : 'sending' }
 SeamlessTransporter >> activateSubstitutionFor: anObject by: aBlock [
 
 	| substitution |
@@ -77,31 +79,31 @@ SeamlessTransporter >> activateSubstitutionFor: anObject by: aBlock [
 	aBlock value: substitution
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessTransporter >> connection [
 	^ connection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessTransporter >> connection: aBasysConnection [
 	connection := aBasysConnection.
 	network := connection network
 ]
 
-{ #category : #sending }
+{ #category : 'sending' }
 SeamlessTransporter >> deepCopyTransferFinishedFor: anObject [
 
 	objectsByDeepCopy removeKey: anObject.
 	objectsByDeepCopy ifEmpty: [ objectsByDeepCopy := nil ]
 ]
 
-{ #category : #sending }
+{ #category : 'sending' }
 SeamlessTransporter >> deepCopyTransferStartedFor: anObject at: pathIndex [
 
 	objectsByDeepCopy at: anObject put: pathIndex
 ]
 
-{ #category : #sending }
+{ #category : 'sending' }
 SeamlessTransporter >> findActiveDeepCopyNodeAndIndex [
 	
 	objectsByDeepCopy associationsDo: [ :objectAndIndex |
@@ -110,13 +112,13 @@ SeamlessTransporter >> findActiveDeepCopyNodeAndIndex [
 	^nil
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessTransporter >> isDeepCopyTransferRequiredFor: anObject [
 
 	^objectsByDeepCopy includesKey: anObject
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SeamlessTransporter >> materializeObject [
 	| request in sizeSize size buffer compressionType compressionStream |
 	in := connection inputStream.
@@ -136,17 +138,17 @@ SeamlessTransporter >> materializeObject [
 	^request
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessTransporter >> network [
 	^ network
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessTransporter >> network: anObject [
 	network := anObject
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 SeamlessTransporter >> prepareTransferObjectFor: anObject [
 
 	| strategy |
@@ -159,7 +161,7 @@ SeamlessTransporter >> prepareTransferObjectFor: anObject [
 	^strategy prepareTransferObjectFor: anObject by: self
 ]
 
-{ #category : #receiving }
+{ #category : 'receiving' }
 SeamlessTransporter >> readObjectReference: anObjectReference [
 	| type uuid |
 	type := self readByte.
@@ -173,11 +175,11 @@ SeamlessTransporter >> readObjectReference: anObjectReference [
 			self error: 'it should not happen'].
 		 ^anObjectReference ownerPeerId: connection remotePeerId].
 	
-	uuid := self readBytes: 16 as: UUID.
+	uuid := self readUUID.
 	^anObjectReference ownerPeerId: uuid
 ]
 
-{ #category : #receiving }
+{ #category : 'receiving' }
 SeamlessTransporter >> readObjectSubstitution [
 
 	| loadedObjectIndex loadedObject localRepresentation |
@@ -192,19 +194,33 @@ SeamlessTransporter >> readObjectSubstitution [
 	^localRepresentation
 ]
 
-{ #category : #accessing }
+{ #category : 'writing' }
+SeamlessTransporter >> readUUID [ 
+	"Mirrors #writeUUID: — rebuilds a UUID by writing the bytes we just
+	 read directly into its named instance variable #uuidData, instead of
+	 relying on MirrorPrimitives setClass:to: (which fails on recent Pharo
+	 versions because UUID and ByteArray no longer share a compatible
+	 low-level object layout)."
+	| bytes uuid |
+	bytes := self readBytes: 16.
+	uuid := UUID new.
+	uuid instVarNamed: #uuidData put: bytes.
+	^uuid
+]
+
+{ #category : 'accessing' }
 SeamlessTransporter >> referenceFor: anObject [
 
 	^self referenceFor: anObject ifNewUse: [anObject createSeamlessReference]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessTransporter >> referenceFor: anObject ifNewUse: refCreationBlock [
 	
 	^network referenceFor: anObject ifNewUse: refCreationBlock.
 ]
 
-{ #category : #api }
+{ #category : 'api' }
 SeamlessTransporter >> serializeObject: aSeamlessRequest [
 	| buffer bufferSizeBytes compressedBytes compressedStream compressionType |
 	objectSubstitutions := IdentityDictionary new.	
@@ -232,7 +248,7 @@ SeamlessTransporter >> serializeObject: aSeamlessRequest [
 		flush
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 SeamlessTransporter >> transfer: anObject byReference: refCreationBlock [
 
 	| reference |
@@ -241,19 +257,19 @@ SeamlessTransporter >> transfer: anObject byReference: refCreationBlock [
 	objectSubstitutions at: anObject put: reference.
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 SeamlessTransporter >> transfer: anObject byReplacement: replacementObject [
 	
 	objectSubstitutions at: anObject put: replacementObject
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 SeamlessTransporter >> transfer: anObject byWellKnownObjectNamed: globalName [
 
 	objectSubstitutions at: anObject put: (SeamlessWellKnownObject named: globalName)
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 SeamlessTransporter >> transferByDeepCopy: anObject [
 
 	self transferByValue: anObject.
@@ -262,13 +278,13 @@ SeamlessTransporter >> transferByDeepCopy: anObject [
 	objectsByDeepCopy at: anObject put: 0
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 SeamlessTransporter >> transferByReference: anObject [
 
 	self transfer: anObject byReference: [anObject createSeamlessReference ]
 ]
 
-{ #category : #controlling }
+{ #category : 'controlling' }
 SeamlessTransporter >> transferByValue: anObject [
 
 	| transferObject |
@@ -278,13 +294,13 @@ SeamlessTransporter >> transferByValue: anObject [
 	objectSubstitutions at: anObject put: transferObject
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SeamlessTransporter >> transfersIdentificationRequest [
 
 	^traveler startNode class = SeamlessPeerIdentificationRequest 
 ]
 
-{ #category : #sending }
+{ #category : 'sending' }
 SeamlessTransporter >> tryWriteTransferObjectFor: anObject format: formatId [
 
 	| transferObject |
@@ -295,7 +311,7 @@ SeamlessTransporter >> tryWriteTransferObjectFor: anObject format: formatId [
 	^true
 ]
 
-{ #category : #sending }
+{ #category : 'sending' }
 SeamlessTransporter >> writeObjectReference: anObjectReference [
 	| type |
 	type := 2 "given reference is alien. It is not belongs to sender or receiver peers".
@@ -308,5 +324,15 @@ SeamlessTransporter >> writeObjectReference: anObjectReference [
 	].
 	self writeByte: type.
 	self writePositiveInteger: anObjectReference id.	
-	type = 2 ifTrue: [ self writeBytes: anObjectReference ownerPeerId]
+	type = 2 ifTrue: [ self writeUUID: anObjectReference ownerPeerId]
+]
+
+{ #category : 'writing' }
+SeamlessTransporter >> writeUUID: aUUID [ 
+	"UUID is no longer Collection-like (no #do:) and no longer become-
+	 compatible with ByteArray via MirrorPrimitives setClass:to: on recent
+	 Pharo versions. It stores its 16 bytes in the named instance variable
+	 #uuidData, which is a real ByteArray understanding #do:. We reach it
+	 directly through reflection instead of assuming UUID's own shape."
+	self writeBytes: (aUUID instVarNamed: #uuidData)
 ]

--- a/Seamless/SeamlessWellKnownObject.class.st
+++ b/Seamless/SeamlessWellKnownObject.class.st
@@ -10,15 +10,17 @@ Internal Representation and Key Implementation Points.
 	name:		<String>
 "
 Class {
-	#name : #SeamlessWellKnownObject,
-	#superclass : #SeamlessTransferObject,
+	#name : 'SeamlessWellKnownObject',
+	#superclass : 'SeamlessTransferObject',
 	#instVars : [
 		'name'
 	],
-	#category : 'Seamless-Core'
+	#category : 'Seamless-Core',
+	#package : 'Seamless',
+	#tag : 'Core'
 }
 
-{ #category : #transfer }
+{ #category : 'transfer' }
 SeamlessWellKnownObject class >> createTostInstanceWith: aSeamlessTransporter [
 	| instance |
 	instance := super createTostInstanceWith: aSeamlessTransporter.
@@ -26,23 +28,23 @@ SeamlessWellKnownObject class >> createTostInstanceWith: aSeamlessTransporter [
 	^instance
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SeamlessWellKnownObject class >> named: aString [
 	^self new 
 		name: aString
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessWellKnownObject >> name [
 	^ name
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SeamlessWellKnownObject >> name: anObject [
 	name := anObject
 ]
 
-{ #category : #transfer }
+{ #category : 'transfer' }
 SeamlessWellKnownObject >> prepareLocalSubstitutionIn: aSeamlessNetwork with: aSeamlessTransporter [
 
 	| global  |
@@ -51,14 +53,14 @@ SeamlessWellKnownObject >> prepareLocalSubstitutionIn: aSeamlessNetwork with: aS
 	^global 
 ]
 
-{ #category : #transfer }
+{ #category : 'transfer' }
 SeamlessWellKnownObject >> travelGuide [
 	"I override normal objects serialization to provide more compact binary format.
 	So I implement custom writeTostBodyWith: method instead of walking by my state by travel guide"
 	^ EmptyObjectTravelGuide 
 ]
 
-{ #category : #transfer }
+{ #category : 'transfer' }
 SeamlessWellKnownObject >> writeTostBodyWith: aSeamlessTransporter [
 	
 	aSeamlessTransporter writeString: name

--- a/Seamless/Slot.extension.st
+++ b/Seamless/Slot.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Slot }
+Extension { #name : 'Slot' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Slot >> seamlessDefaultTransferStrategy [
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/SmallDictionary.extension.st
+++ b/Seamless/SmallDictionary.extension.st
@@ -1,13 +1,13 @@
-Extension { #name : #SmallDictionary }
+Extension { #name : 'SmallDictionary' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 SmallDictionary >> prepareValueTransferBy: aSeamlessTransporter [
 
 	aSeamlessTransporter transferByValue: keys.
 	aSeamlessTransporter transferByValue: values
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 SmallDictionary >> seamlessDefaultTransferStrategy [ 
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/String.extension.st
+++ b/Seamless/String.extension.st
@@ -1,16 +1,16 @@
-Extension { #name : #String }
+Extension { #name : 'String' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 String class >> definesWellKnownSeamlessClass [ 
 	^self package = String package
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 String class >> definesWellKnownSeamlessClassHierarchy [ 
 	^true
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 String >> seamlessDefaultTransferStrategy [
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/Text.extension.st
+++ b/Seamless/Text.extension.st
@@ -1,12 +1,12 @@
-Extension { #name : #Text }
+Extension { #name : 'Text' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Text >> prepareValueTransferBy: aSeamlessTransporter [
 	
 	aSeamlessTransporter transferByValue: runs
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Text >> seamlessDefaultTransferStrategy [ 
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/Time.extension.st
+++ b/Seamless/Time.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Time }
+Extension { #name : 'Time' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Time >> seamlessDefaultTransferStrategy [
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/Timespan.extension.st
+++ b/Seamless/Timespan.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #Timespan }
+Extension { #name : 'Timespan' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 Timespan >> seamlessDefaultTransferStrategy [
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/UUID.extension.st
+++ b/Seamless/UUID.extension.st
@@ -1,16 +1,16 @@
-Extension { #name : #UUID }
+Extension { #name : 'UUID' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 UUID class >> definesWellKnownSeamlessClass [ 
 	^true
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 UUID >> isOnlyDefaultTransferStrategyAllowed [
 	^true
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 UUID >> seamlessDefaultTransferStrategy [ 
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/UndefinedObject.extension.st
+++ b/Seamless/UndefinedObject.extension.st
@@ -1,16 +1,16 @@
-Extension { #name : #UndefinedObject }
+Extension { #name : 'UndefinedObject' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 UndefinedObject class >> definesWellKnownSeamlessClass [
 	^true
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 UndefinedObject >> isOnlyDefaultTransferStrategyAllowed [
 	^true
 ]
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 UndefinedObject >> seamlessDefaultTransferStrategy [
 	^SeamlessTransferStrategy defaultByValue
 ]

--- a/Seamless/WorkspaceVariable.extension.st
+++ b/Seamless/WorkspaceVariable.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #WorkspaceVariable }
+Extension { #name : 'WorkspaceVariable' }
 
-{ #category : #'*Seamless' }
+{ #category : '*Seamless' }
 WorkspaceVariable class >> definesWellKnownSeamlessClass [
 	^true
 ]

--- a/Seamless/package.st
+++ b/Seamless/package.st
@@ -1,1 +1,1 @@
-Package { #name : #Seamless }
+Package { #name : 'Seamless' }


### PR DESCRIPTION
oliveiraallex: This is the result of many sessions to port the Pharo IoT suite to Pharo 13. With these fixies the Seamless can open a session between two remote Pharo 13 images and work basicaly, transcript and inspect the remote objects. It still WIP. Full description bellow.

Reference doc: [Porting Pharo IoT](https://github.com/pharo-iot/PharoThings/wiki/Porting-Pharo-IoT-:-PharoThings-%E2%80%90-Seamless-%E2%80%90-TelePharo-%E2%86%92-Pharo-13)

This document was generated with AI assistance, then manually reviewed and adjusted by Allex OLIVEIRA, incorporating all findings and fixes from the porting work.

---

First end-to-end client↔server test of Seamless in this project (previously only validated by loading). Images: **v5** = server (`TestSeamlessServer`, port 40417), **v6** = client (`TestSeamlessClient3`/`4`), **v1** = read-only pristine reference clone of `pharo-ide/Seamless`/`Calypso` (`Pharo 13.0 - 64bit - v1\pharo-local\iceberg\pharo-ide\`).

"Pharo 9" below = last confirmed-matching API version. Local source trees for 9/11/12/13 used for direct comparison where noted.

## Table of all problems

| # | Package | Class | Method | Before | After | Type | Status |
|---|---|---|---|---|---|---|---|
| 1 | Seamless | `SeamlessRequestResultTimelyDelivery` | `waitResult` | `wait: 100 milliSeconds` | `waitTimeoutMilliseconds: 100` | Deprecated API | Fixed, both images |
| 2 | Seamless | `SeamlessRequestResultDelivery` | `waitResult` | `wait: 100 milliSeconds` | `waitTimeoutMilliseconds: 100` | Deprecated API | Fixed, both images |
| 3 | Seamless | `BlockClosure` ext. | `prepareValueTransferBy:` | assumed non-nil outer-context chain (3 spots) | 3 nil-guards | Missing nil-handling | Fixed, both images |
| 4 | TostSerializer | `CleanBlockClosure` ext. | `correctTostMaterializationWith:`, `createTostInstanceWith:`, `writeTostBodyWith:` | not implemented, fell through to broken `BlockClosure` original | 3 no-op/simplified overrides mirroring `FullBlockClosure` | Missing override, post-block-redesign | Fixed, both images |
| 5 | Seamless | `SeamlessNetwork` instance | `transferStrategies` | left overridden by an earlier, unreverted test (forced `OrderedCollection` by-value) | override cleared | Test artifact, not a bug | Resolved |
| 6 | Seamless-NewToolsSupport | `SeamlessRemoteClassCompiler` | `evaluate` | 6 calls to APIs removed/renamed since Pharo 9 | updated to current `OpalCompiler` API | API drift | Fixed, both images |
| 7 | Seamless-NewToolsSupport | `SeamlessProxy` ext. | `remoteInspection` | 0-arg method (old inspection-pragma convention) | proposed: `remoteInspection: aBuilder` | API drift | Proposed, **not applied/tested** |

## Starting point → final point

Connection layer (1–5): fixed, stable, self-healing. `evaluate:`/`evaluateAsync:` work for all block types. Full regression pass on every scenario in `Seamless-Como-Funciona.md` (creation/manipulation by reference, forced by-value, exceptions, non-local return, recursive evaluate, identity round-trip) — all pass. Sessions/servers closed clean on both images.

Inspector layer (6–7): item 6 is a real, separately-confirmed bug, fixed. It did **not** fix the reported symptom (Inspector "Remote" tab on a `SeamlessProxy` showing a static error instead of a live browser). Actual cause isolated in item 7: `remoteInspection` uses the old zero-arg pragma convention NewTools no longer supports. Fix proposed, not yet applied or tested.

## Items 1–2: deprecated `Semaphore>>wait:` in two result-delivery classes

**Symptom:** connections handshake fine, then later the reader process crashes with `Error: it should not happen` (`SeamlessTransporter>>readObjectReference:`), or requests silently time out (`SeamlessRequestTimeout`).

**Root cause:** `Semaphore>>wait:` is deprecated; the resulting `Deprecation` isn't auto-resumed outside an interactive debugger prompt, so it aborts mid-call. `SeamlessRequestResultDelivery>>waitResult` is used specifically by `identifyLocalPeerOn:` — when the abort happens there, it fires *before* `ensureIdentity:`, leaving the connection `isOpened: true` / `isIdentified: false`. `BasysConnection>>isValid` only checks socket health, not identification, so the pool keeps reusing the half-identified connection until it crashes the reader process on next use.

**Why it didn't self-heal:** the reader process runs as `[ self incomingDataLoop ] ensure: [ self close ]`. `close` (the actual cleanup) only fires on process *unwind*, not suspension — a debugger opened on the crash leaves the process suspended, not unwound, so the pool stays corrupted until the debug session is **terminated** (not resumed).

**Why two fixes:** fixing `SeamlessRequestResultTimelyDelivery` alone fixed already-identified connections, but every new/reconnecting connection still hit the sibling class in `identifyLocalPeerOn:`. Found only after previously-working scenarios started timing out again.

**Fix (both classes, both images):**
```smalltalk
waitResult
	"Instead of blindly wait for delivery result forever we periodically check the connection status
	and consider the deliver as unavailable when senderPeer is not connected anymore."
	[requestResult isNil and: [ senderPeer isConnected ] ]
		whileTrue: [ synchronizationSemaphore waitTimeoutMilliseconds: 100 ].
	requestResult ifNil: [ SeamlessResultDeliveryUnavailable signal ]
```
Confirmed via `method_compile` → `changeKind: replaced` on both images.

## Item 3: `prepareValueTransferBy:` crashes on blocks with no outer context

**Symptom:** `peer evaluate: [1 + 2]` worked; `peer evaluate: [12]`/`[42]` (constant/clean blocks — legitimately `outerContext == nil`) crashed on the sending side.

**Root cause — `BlockClosure(Seamless)>>prepareValueTransferBy:`, three unguarded nil sends:**
1. `self hasMethodReturn` — only exists on `CompiledBlock`, not `BlockClosure` → needed `self method hasMethodReturn`.
2. `mostOuterContext closure notNil` — sends to nil once the walk reaches a contextless block → needed `mostOuterContext notNil and: [...]`.
3. `aSeamlessTransporter transferByValue: mostOuterContext method` — same, unconditional → needed `mostOuterContext ifNotNil: [...]`.

**Fix:** all three guarded, both images. Verified: `[12]`, `[42]`, `[1+2]`, and an argument-taking block all transfer clean.

## Item 4: TostSerializer materialization crash — stale `startpc` on `CleanBlockClosure`

**Symptom:** after item 3, sending succeeds but the receiver crashes materializing it: `UndeclaredVariableRead: startpc`.

**Root cause:** block-closure representation changed in Pharo 11 (confirmed against local Pharo 9/11 source; Pharo 11 release notes: "Extended Full Blocks and Constant Clock closures support"). Pre-11: `BlockClosure` had `outerContext`/`startpc`/`numArgs`, bytecode inline. Pharo 11+: split into `outerContext`/`compiledBlock`/`numArgs`, three concrete subclasses (`FullBlockClosure`, `CleanBlockClosure`, `ConstantBlockClosure` < `CleanBlockClosure`).

TostSerializer's `BlockClosure>>correctTostMaterializationWith:` does a word-size correction on `startpc` — meaningless post-redesign (no `startpc`; bytecode lives on `compiledBlock`, already handled by Tost's generic `CompiledCode` path). `FullBlockClosure` already has a correct no-op override; `CleanBlockClosure`/`ConstantBlockClosure` never got one and fell through to the broken original.

Checked `origin/pharo9-deprecation-methods` branch — same broken code, no fix there either. Grepped `seamless`/`Ghost`/`Basys` for `startpc`/`CleanBlockClosure`/`ConstantBlockClosure`/`FullBlockClosure` — zero hits outside TostSerializer, confirming the blast radius is contained to it.

**Fix (mirrors `FullBlockClosure`, covers `ConstantBlockClosure` via inheritance):**
```smalltalk
correctTostMaterializationWith: materializedWordSize
	"No difference in binary presentation in 32/64 bit images. Nothing to do."

createTostInstanceWith: aTostTransporter   "class-side"
	^self basicNew: aTostTransporter readPositiveInteger

writeTostBodyWith: aTostTransporter
	aTostTransporter writePositiveInteger: self size
```
Verified: `peer evaluate: [12]` → `12`, `peer evaluate: [1 + 2]` → `3`.

**Not verified:** `CompiledBlock`/`CompiledCode` Tost materialization across word sizes (32↔64-bit) — both images are 64-bit, scenario never arose. Flag before any 32-bit target.

## Item 5: identity round-trip "gap" — test artifact, not a bug

**Symptom:** sending a local `OrderedCollection` and getting it back returned a content-equal but non-identical (`==` false) copy.

**Root cause:** an earlier by-value-transfer test (manual section 9.4) had called `net transferByValue: (Instance of: OrderedCollection)` and never reverted it — this persistently reconfigures the network object itself, so every later test on it silently copied `OrderedCollection`s by value.

**Fix:** `net instVarNamed: #transferStrategies put: SortedCollection new`. Re-ran identity tests (captured-variable and message-argument) — both `true`. No framework defect.

## Regression pass

All manual-documented scenarios pass on both images: creation/manipulation by reference, forced by-value, exception propagation, identity round-trip, recursive bidirectional evaluate, `evaluateAsync:`, simple non-local return. Known, untouched, out-of-scope failure: `testEvaluatingBlockWhichCallRecursiveBlockEvaluationToSenderPeerWithNonLocalReturn` (non-local return through a recursive cross-peer call), marked `<expectedFailure>` upstream.

Sessions closed clean at end of this arc on both images — zero registered peers, zero listening servers, zero stuck debug sessions.

## Item 6: `SeamlessRemoteClassCompiler>>evaluate` — six points of API drift since Pharo 9

**Found via:** Inspector "Remote" tab on a `SeamlessProxy` showing `MessageNotUnderstood: #getSourceFromRequestorSelection` instead of a live browser. (Later shown in item 7 to be an incidental trigger, not the actual cause of the tab failure.)

**Git history (`oliveiraallex/seamless`):**
- `961bc3e` "moved from smalltalkhub" — original pre-2021 inline implementation.
- `bb6fa74` — Marcus Denker <marcus.denker@inria.fr>, 2021-06-17 — rewrote to use `getSourceFromRequestorSelection`/`compileDoit`/`noPattern:`, all valid Pharo 9 `OpalCompiler` API at the time (authored by a Pharo core dev, not a fork mistake).
- `8f8879d` — "Remove previous extensions..."
- `91af5c0` — dionisiydk <dionisiydk@gmail.com>, 2022-12-22 — created `Seamless-NewToolsSupport/SeamlessRemoteClassCompiler.class.st` fresh; method body carried over byte-for-byte from the GTSupport version. The NewTools port migrated the presentation layer but never re-validated the compiler internals against post-Pharo-9 `OpalCompiler`.
- `origin/pharo9-deprecation-methods` branch checked — same broken code, abandoned, not a source of a fix.

**`noPattern:` vs `isScripting:` discrepancy (live image vs. git):** confirmed technically as Pharo's own automatic rewrite mechanism, not manual editing. `OpalCompiler>>noPattern:` self-deprecates via `deprecated:transformWith:` (`Deprecation` < `AutomaticRewriting`), which auto-rewrites call sites when the deprecated selector executes.

**Six drift points, all from the Pharo 11+ `semanticScope`-based compiler redesign:**

1. `getSourceFromRequestorSelection` — removed; caller now configures `source:` before calling `evaluate`. Delete.
2. `compileDoit` → renamed `compile`.
3. Bare `context`/`receiver` ivars — removed. `receiver` survives as computed accessor (`self receiver`); `context` has no getter at all (write-only via `context:`). Real setup site `SpCodeInteractionModel>>compiler` configures `context:`/`receiver:`/`requestor:` on construction — since there's no getter for `context`, fixed to read `self requestor doItContext` instead.
4. `self compilationContext requestor` — `OCCompilationContext` doesn't understand `#requestor`; it's an `OpalCompiler` accessor. Fixed to `self requestor`.
5. `self compilationContext failBlock` — same pattern. Fixed to `self failBlock`.
6. `SyntaxErrorNotification` → renamed `OCSyntaxErrorNotice`.

Plus: `self logDoIt` doesn't exist. Modern equivalent, from `OpalCompiler>>evaluate`'s own tail: `self logged == true ifTrue: [ self semanticScope announceDoItEvaluation: source by: self class codeSupportAnnouncer ]`.

**Fix (both images):**
```smalltalk
evaluate
	| value doItContext |
	self isScripting: true.
	doItContext := self requestor doItContext.
	self class: (doItContext
			 ifNil: [ self receiver remoteClass ]
			 ifNotNil: [ doItContext compiledCode methodClass ]).
	compilationContext productionEnvironment: self class environment.
	value := [
		self receiver
			withArgs: (doItContext ifNil: [ #(  ) ] ifNotNil: [ { doItContext } ])
			executeMethod: self compile ]
		on: OCSyntaxErrorNotice
		do: [ :exception |
			self requestor
				ifNotNil: [
					self requestor
						notify: exception errorMessage , ' ->'
						at: exception location
						in: exception errorCode.
					self failBlock value ]
				ifNil: [ exception pass ] ].
	self logged == true ifTrue: [
		self semanticScope announceDoItEvaluation: source by: self class codeSupportAnnouncer ].
	^ value
```

**Side note:** the debug repro panel (`StInspectionContext>>debugInspectorPresenter:`) prepends a literal string line before real temp-var declarations (`| collector pragma context |`). Selecting from line 1 and executing raises `variable expected in assigment` — Smalltalk requires temp declarations to be the first statement. Select from line 2 onward.

**Status:** applied, compiled on both images, matches source above. Verified via `method_compile` (`changeKind: replaced`) and headless `image_evaluate`. Did **not** fix the Inspector "Remote" tab symptom — see item 7.

## Item 7: actual root cause of the "Remote" tab failure

**Reproduced headlessly** (client v6 ↔ server v5, restarted on port 40417), walking `StInspectionContext`'s own internal call chain:
1. `collector := StInspectionCollector on: self` — ok.
2. `pragma := (SeamlessProxy lookupSelector: #remoteInspection) pragmas first` — ok.
3. `context := collector basicContextFromPragma: pragma` — ok.
4. `context basicNewInspectionPresenter` — **fails**: `Warning: Inspections made without presenter builder are no longer supported...`

Confirms item 6's fix was a real bug but an incidental trigger, not the cause — it was only reached because the debug repro snippet's own `self` binds to the proxy, routing that snippet's compilation through `SeamlessRemoteClassCompiler`.

**Root cause (`StInspectionContext`, current NewTools):**
```smalltalk
basicNewInspectionPresenter: aBuilder
	^ self methodSelectorNeedsBuilder
		ifTrue: [ self inspectedObject inspectorPerform: self methodSelector with: aBuilder ]
		ifFalse: [
			Warning signal: 'Inspections made without presenter builder are no longer supported...'.
			^ nil ]

methodSelectorNeedsBuilder
	^ self methodSelector last = $:
```
`remoteInspection` (`SeamlessProxy.extension.st`, `Seamless-NewToolsSupport`) is a **zero-argument** method — selector doesn't end in `:`, so `methodSelectorNeedsBuilder` is false and the Inspector refuses to build the presenter. Confirmed against a known-working sibling using the modern convention:
```smalltalk
inspectionMeta: aBuilder
	<inspectorPresentationOrder: 999 title: 'Meta'>
	^ aBuilder instantiate: StMetaBrowserPresenter on: self
```
`SeamlessRemoteObjectInspection` itself (< `GHGhostRawInspection` < `StRawInspectionPresenter`, same base the "Raw" tab uses) is fine — tested headlessly against a live proxy, `inspectorNodes`/`setAttributeTable` work correctly. The bug is purely in how `remoteInspection` is declared, not in what it builds.

**Invocation mechanism (how a new `xxx: aBuilder` method gets called with nothing referencing it by name):** NewTools discovers inspection methods reflectively via `Pragma allNamed:from:to:`, scanning for `<inspectorPresentationOrder:title:>` regardless of method name/arity, then invokes through `ProtoObject>>inspectorPerform:with:` (primitive 83 — a reflective send that works even on `SeamlessProxy`'s `superclass: nil` Ghost object). No call site needed; same mechanism already invokes `inspectionMeta:`.

**Proposed fix:**
```smalltalk
remoteInspection: aBuilder
	"This is the most basic presentation showing the state of the object"
	<inspectorPresentationOrder: 1000 title: 'Remote'>
	^ aBuilder instantiate: SeamlessRemoteObjectInspection on: self
```

**Status:** proposed only. Next step: apply on both images, confirm actual GUI rendering (not just the headless call chain up to presenter construction).

## Old GTTools-era Seamless inspection code — reference only

Read from the pristine `pharo-ide/Seamless` clone (v1). `Seamless-GTSupport/SeamlessObjectVariablesBrowser` — read-only table browser, roughly equivalent to today's `SeamlessRemoteObjectInspection`. `SeamlessProxy.extension.st` (GT era) had `gtInspectorRawIn:` (`<gtInspectorPresentationOrder: 10>`, plain Inspector — ancestor of today's "Remote" tab) and `gtDebuggerEvaluatorIn:` (`<gtDebuggerPresentationOrder: 10>`, genuinely interactive evaluator via `SeamlessRemoteScriptPresentation`, but **Debugger-scoped only**).

Confirms: interactive remote evaluation was never a plain-Inspector feature, so its absence today isn't a regression. Only support classes (`SeamlessRemoteScriptResult`, `SeamlessRemoteWorkspaceVariable`) survived the NewTools port — the actual presenter (`SeamlessRemoteScriptPresentation`/`Renderer`) was never ported. Building it in the Inspector would need fresh NewTools/Spec2 work, not reactivation.

## What still needs to be done

- Apply and visually confirm item 7's fix on both images.
- Not verified: `CompiledBlock`/`CompiledCode` Tost materialization across word sizes (32↔64-bit).
- Out of scope, known upstream gap: recursive non-local-return test, `<expectedFailure>`.
- Deferred: WiringPi/Firmata fixes, TlpPlayground2 activation.
- **Nothing committed yet.** All of items 1–4 and 6 exist only as live compiled changes on v5/v6; item 7 is proposed only. No commits made against `oliveiraallex/seamless` or `oliveiraallex/TostSerializer`.
- Unaudited risk: item 6 showed one method can accumulate several compounding points of drift across Pharo compiler redesigns without being caught until actually exercised. No systematic sweep of the rest of `Seamless-NewToolsSupport`/`Seamless-GTSupport` against current APIs has been done — items 6 and 7 were found only because real usage surfaced them.
